### PR TITLE
Show bot webhook address in full on the settings page

### DIFF
--- a/cmd/informer-ui/binding_manage_test.go
+++ b/cmd/informer-ui/binding_manage_test.go
@@ -321,7 +321,7 @@ func TestConfigBindingsRoundTrip(t *testing.T) {
 	assert.Equal(t, 15, view.Feed.MaxInformFeedSize)
 }
 
-func TestWebhookBindingKeepsTheSecretOutOfTheFrontend(t *testing.T) {
+func TestWebhookBindingReturnsTheStoredAddress(t *testing.T) {
 	t.Parallel()
 
 	app := newTestApp(t)
@@ -337,7 +337,7 @@ func TestWebhookBindingKeepsTheSecretOutOfTheFrontend(t *testing.T) {
 	view, err = app.ReadSecrets()
 	require.NoError(t, err)
 	assert.True(t, view.WebhookConfigured)
-	assert.NotContains(t, view.WebhookMasked, "secret-token")
+	assert.Equal(t, webhook, view.Webhook)
 
 	if runtime.GOOS != "windows" {
 		info, statErr := os.Stat(view.Path)

--- a/cmd/informer-ui/binding_settings.go
+++ b/cmd/informer-ui/binding_settings.go
@@ -52,13 +52,13 @@ type ConfigViewDTO struct {
 	PreservedKeys []string `json:"preservedKeys"`
 }
 
-// SecretsViewDTO is the credential state of the settings page. The webhook itself
-// never crosses the binding: the page only learns that one is configured.
+// SecretsViewDTO is the credential state of the settings page. The webhook is a
+// plain bot address rather than a secret, so the page shows it in full.
 type SecretsViewDTO struct {
 	Path              string `json:"path"`
 	Exists            bool   `json:"exists"`
 	WebhookConfigured bool   `json:"webhookConfigured"`
-	WebhookMasked     string `json:"webhookMasked"`
+	Webhook           string `json:"webhook"`
 }
 
 // HistoryIndexDTO reports what one history index rebuild did.
@@ -151,7 +151,7 @@ func (a *App) ReadSecrets() (*SecretsViewDTO, error) {
 		Path:              view.Path,
 		Exists:            view.Exists,
 		WebhookConfigured: view.WebhookConfigured,
-		WebhookMasked:     view.WebhookMasked,
+		Webhook:           view.Webhook,
 	}, nil
 }
 

--- a/cmd/informer-ui/frontend/src/SettingsPanel.vue
+++ b/cmd/informer-ui/frontend/src/SettingsPanel.vue
@@ -42,7 +42,7 @@ const form = reactive({
 
 const secretsPath = ref('')
 const webhookConfigured = ref(false)
-const webhookMasked = ref('')
+const webhook = ref('')
 const webhookInput = ref('')
 const webhookSaving = ref(false)
 
@@ -65,7 +65,7 @@ async function load() {
 
     secretsPath.value = secrets.path
     webhookConfigured.value = secrets.webhookConfigured
-    webhookMasked.value = secrets.webhookMasked
+    webhook.value = secrets.webhook
   } catch (e) {
     loadError.value = errorText(e)
   } finally {
@@ -167,7 +167,7 @@ async function rebuild() {
         </template>
       </n-card>
 
-      <n-card size="small" title="机器人地址（敏感配置）" style="margin-bottom: 16px">
+      <n-card size="small" title="机器人地址" style="margin-bottom: 16px">
         <n-text depth="3" style="font-size: 12px">
           存放于独立文件 <n-code :code="secretsPath" inline />，权限固定为 0600，不写入 informer.json，也不入库。
         </n-text>
@@ -177,15 +177,13 @@ async function rebuild() {
             <n-space :size="8" align="center">
               <n-tag v-if="webhookConfigured" size="small" type="success">已配置</n-tag>
               <n-tag v-else size="small" :bordered="false">未配置</n-tag>
-              <n-text v-if="webhookMasked" depth="3" style="font-size: 12px">{{ webhookMasked }}</n-text>
+              <n-text v-if="webhook" depth="3" style="font-size: 12px">{{ webhook }}</n-text>
             </n-space>
           </n-descriptions-item>
         </n-descriptions>
 
         <n-input
           v-model:value="webhookInput"
-          type="password"
-          show-password-on="click"
           placeholder="粘贴钉钉 / 飞书机器人 webhook；留空保存表示清除"
         />
 

--- a/internal/service/secrets.go
+++ b/internal/service/secrets.go
@@ -27,20 +27,14 @@ import (
 const (
 	// SecretsFileName is the credential file of one data directory. It is kept out of
 	// informer.json on purpose: informer.json is meant to be readable, diffable and
-	// shareable, a bot webhook is not.
+	// shareable, while the bot webhook stays in its own locked-down file.
 	SecretsFileName = "informer.secret.json"
 
 	// webhookKey is the top level key holding the bot webhook.
 	webhookKey = "webhook"
-
-	// maskKeepChars is how many leading characters of a webhook stay visible when the
-	// settings page shows which credential is configured.
-	maskKeepChars = 24
 )
 
 // SecretsView is what the settings page learns about the credential file.
-// The webhook itself never leaves the backend: the page only sees whether one is
-// configured and a masked hint identifying it.
 type SecretsView struct {
 	// Path is the absolute location of the credential file.
 	Path string `json:"path"`
@@ -51,8 +45,9 @@ type SecretsView struct {
 	// WebhookConfigured reports whether a non empty webhook is stored.
 	WebhookConfigured bool `json:"webhook_configured"`
 
-	// WebhookMasked identifies the stored webhook without revealing its token.
-	WebhookMasked string `json:"webhook_masked"`
+	// Webhook is the stored bot address. It is a plain endpoint rather than a
+	// secret, so the settings page shows it in full.
+	Webhook string `json:"webhook"`
 }
 
 // SecretsFilePath is the credential file of the active data directory.
@@ -73,7 +68,7 @@ func (s *Service) ReadSecretsView() (*SecretsView, error) {
 		Path:              path,
 		Exists:            stored.exists,
 		WebhookConfigured: stored.webhook != "",
-		WebhookMasked:     maskSecret(stored.webhook),
+		Webhook:           stored.webhook,
 	}, nil
 }
 
@@ -148,18 +143,4 @@ func (s *Service) readWebhook() (storedSecrets, error) {
 	}
 
 	return storedSecrets{webhook: strings.TrimSpace(webhook), exists: doc.Exists()}, nil
-}
-
-// maskSecret keeps the identifying prefix of a credential and hides the rest.
-func maskSecret(secret string) string {
-	if secret == "" {
-		return ""
-	}
-
-	runes := []rune(secret)
-	if len(runes) <= maskKeepChars {
-		return strings.Repeat("*", len(runes))
-	}
-
-	return string(runes[:maskKeepChars]) + strings.Repeat("*", 8)
 }

--- a/internal/service/settings_test.go
+++ b/internal/service/settings_test.go
@@ -164,7 +164,7 @@ func TestSaveWebhookWritesASensitiveFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, view.Exists)
 	assert.False(t, view.WebhookConfigured)
-	assert.Empty(t, view.WebhookMasked)
+	assert.Empty(t, view.Webhook)
 
 	const webhook = "https://oapi.dingtalk.com/robot/send?access_token=super-secret-token"
 
@@ -174,8 +174,9 @@ func TestSaveWebhookWritesASensitiveFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, view.Exists)
 	assert.True(t, view.WebhookConfigured)
-	assert.NotContains(t, view.WebhookMasked, "super-secret-token")
-	assert.Contains(t, view.WebhookMasked, "oapi.dingtalk.co")
+
+	// the bot address is a plain endpoint, so the settings page sees it in full.
+	assert.Equal(t, webhook, view.Webhook)
 
 	assertSecretPermission(t, svc.SecretsFilePath())
 


### PR DESCRIPTION
The bot webhook is a plain endpoint rather than a secret, so treat it as regular configuration on the settings page.

## Changes
- The stored address is now shown in full in the 「当前状态」 row instead of a masked hint.
- The input no longer masks its value as a password (removed `type="password"` / `show-password-on`).
- Card title 「机器人地址（敏感配置）」 → 「机器人地址」.
- Backend: `SecretsView` / `SecretsViewDTO` now return the real `webhook` instead of `webhookMasked`; removed the `maskSecret` helper and `maskKeepChars` constant.
- Tests updated to assert the full address is returned.

The address still lives in the separate `0600` `informer.secret.json` file — only the display/input masking changed, not the file-level storage protection.

## Verification
- `go build` + `go test` green for both Go modules.
- `vue-tsc` typecheck passes.
- `golangci-lint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)