### PR TITLE
feat: add informer app icon (reading + notification)

### DIFF
--- a/assets/app-icon.svg
+++ b/assets/app-icon.svg
@@ -1,0 +1,39 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Informer app icon">
+  <defs>
+    <linearGradient id="tile" x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#3730A3"/>
+    </linearGradient>
+    <linearGradient id="badge" x1="0" y1="0" x2="24" y2="24" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FDBA74"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+    <mask id="knock">
+      <rect x="0" y="0" width="24" height="24" fill="#fff"/>
+      <circle cx="18.4" cy="5.6" r="4.2" fill="#000"/>
+    </mask>
+  </defs>
+
+  <!-- rounded-square tile -->
+  <rect x="0" y="0" width="512" height="512" rx="116" fill="url(#tile)"/>
+
+  <!-- mark, centered -->
+  <g transform="translate(123 128) scale(11.08)">
+    <g mask="url(#knock)" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 6.3
+               C 10.1 5.0, 7.4 4.6, 4.8 5.1
+               L 4.8 17.7
+               C 7.4 17.2, 10.1 17.6, 12 18.9
+               C 13.9 17.6, 16.6 17.2, 19.2 17.7
+               L 19.2 5.1
+               C 16.6 4.6, 13.9 5.0, 12 6.3 Z"/>
+      <path d="M12 6.3 L12 18.9"/>
+      <path d="M7.3 9.6 h2.7"/>
+      <path d="M7.3 12.0 h2.7"/>
+      <path d="M7.3 14.4 h2.0"/>
+      <path d="M14.0 12.0 h2.7"/>
+      <path d="M14.0 14.4 h2.0"/>
+    </g>
+    <circle cx="18.4" cy="5.6" r="3.0" fill="url(#badge)"/>
+  </g>
+</svg>

--- a/assets/icon-mono.svg
+++ b/assets/icon-mono.svg
@@ -1,0 +1,27 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Informer">
+  <defs>
+    <mask id="knock">
+      <rect x="0" y="0" width="24" height="24" fill="#fff"/>
+      <circle cx="18.4" cy="5.6" r="4.1" fill="#000"/>
+    </mask>
+  </defs>
+
+  <!-- inherits currentColor so it adapts to light/dark UI -->
+  <g mask="url(#knock)" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 6.3
+             C 10.1 5.0, 7.4 4.6, 4.8 5.1
+             L 4.8 17.7
+             C 7.4 17.2, 10.1 17.6, 12 18.9
+             C 13.9 17.6, 16.6 17.2, 19.2 17.7
+             L 19.2 5.1
+             C 16.6 4.6, 13.9 5.0, 12 6.3 Z"/>
+    <path d="M12 6.3 L12 18.9"/>
+    <path d="M7.3 9.6 h2.7"/>
+    <path d="M7.3 12.0 h2.7"/>
+    <path d="M7.3 14.4 h2.0"/>
+    <path d="M14.0 12.0 h2.7"/>
+    <path d="M14.0 14.4 h2.0"/>
+  </g>
+
+  <circle cx="18.4" cy="5.6" r="3.0" fill="currentColor"/>
+</svg>

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,39 @@
+<svg width="120" height="120" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Informer — reading + notification">
+  <defs>
+    <linearGradient id="book" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6366F1"/>
+      <stop offset="1" stop-color="#4338CA"/>
+    </linearGradient>
+    <linearGradient id="badge" x1="15" y1="3" x2="21" y2="9" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FB923C"/>
+      <stop offset="1" stop-color="#F97316"/>
+    </linearGradient>
+    <!-- knock the book out from under the badge so the dot reads cleanly on any background -->
+    <mask id="knock">
+      <rect x="0" y="0" width="24" height="24" fill="#fff"/>
+      <circle cx="18.4" cy="5.6" r="4.1" fill="#000"/>
+    </mask>
+  </defs>
+
+  <!-- Open book = reading -->
+  <g mask="url(#knock)" stroke="url(#book)" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 6.3
+             C 10.1 5.0, 7.4 4.6, 4.8 5.1
+             L 4.8 17.7
+             C 7.4 17.2, 10.1 17.6, 12 18.9
+             C 13.9 17.6, 16.6 17.2, 19.2 17.7
+             L 19.2 5.1
+             C 16.6 4.6, 13.9 5.0, 12 6.3 Z"/>
+    <path d="M12 6.3 L12 18.9"/>
+    <!-- text lines = the act of reading -->
+    <path d="M7.3 9.6 h2.7"/>
+    <path d="M7.3 12.0 h2.7"/>
+    <path d="M7.3 14.4 h2.0"/>
+    <path d="M14.0 12.0 h2.7"/>
+    <path d="M14.0 14.4 h2.0"/>
+  </g>
+
+  <!-- Notification dot = informing -->
+  <circle cx="18.4" cy="5.6" r="3.0" fill="url(#badge)"/>
+  <circle cx="18.4" cy="5.6" r="1.05" fill="#FFFFFF"/>
+</svg>


### PR DESCRIPTION
## What

A custom SVG mark for **informer** that fuses the two ideas baked into the project name:

- **Reading** — an open book with short text lines on each page.
- **Informing / notification** — a dot knocked out cleanly above the page corner, like an unread badge.

The two are welded together with an SVG `<mask>` that bites a transparent gap out of the book beneath the badge. That single trick is what lets the dot read on *any* background — and it's exactly why the monochrome variant works without a hard-coded background color.

## Variants

| File | Use | Notes |
|---|---|---|
| `assets/icon.svg` | Full-color brand mark | Indigo book gradient + amber notification dot |
| `assets/icon-mono.svg` | In-app UI | Pure `currentColor`; follows light / dark themes |
| `assets/app-icon.svg` | Launch icon / avatar | Rounded-square tile, white mark on indigo, amber dot |

Color tokens, for aligning with any existing brand palette:

- Book / body — `#6366F1 → #4338CA`
- Notification dot — `#FB923C → #F97316` (on the tile: `#FDBA74 → #F59E0B`)
- Mono variant — `currentColor`

## Scope note

This is branched straight off `master` and is **independent of #30** (the webhook-address PR). The icon work was authored on a checkout that happened to be sitting on `feat/webhook-plain-display`, but it has nothing to do with that feature, so it lives on its own branch to keep both PRs reviewable in isolation.

## Verification

- Rendered both marks to PNG (`assets/preview/`, not committed — local rasterizations) and visually checked the book/badge composition and the knockout gap on color, mono, and tile backgrounds.
- SVGs are self-contained (gradients + mask defined inline), so they drop into any `<img>`, CSS `background`, or component without external deps.
