### PR TITLE
fix(inform): timeout-bound push requests so a hung bot frees the inform lock

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,18 @@ linters:
       - linters:
           - paralleltest
         path: internal/service/.*_test\.go
+      # the ding, lark and soup tests swap the package level delivery client to
+      # shorten the production 60s deadline, a write to a shared global; the
+      # tests of each package therefore have to stay sequential.
+      - linters:
+          - paralleltest
+        path: internal/(ding|lark|soup)/.*_test\.go
+      # the manual push timeout tests swap the outbound clients of ding, lark
+      # and soup for a short deadline; they must not overlap the parallel
+      # trigger tests that exercise the production clients.
+      - linters:
+          - paralleltest
+        path: binding_inform_timeout_test\.go
       - linters:
           - gosec
         text: Potential HTTP request made with variable url

--- a/cmd/informer-ui/binding_inform_timeout_test.go
+++ b/cmd/informer-ui/binding_inform_timeout_test.go
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+// The tests in this file deliberately stay sequential: they swap the outbound
+// clients of ding, lark and soup to shorten the production 60s deadline, and
+// an overlapping parallel trigger test that reads those clients would race
+// with the swap.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/ding"
+	"github.com/vogo/informer/internal/lark"
+	"github.com/vogo/informer/internal/soup"
+)
+
+// frozenBotServer serves accepting bots and freezes every other path until the
+// test ends, so one trigger can hang on a delivery while the next one proves
+// the guard is free again.
+func frozenBotServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	release := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/feishu.cn/ok", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"code":0}`))
+	})
+	mux.HandleFunc("/dingtalk.com/ok", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"errcode":0}`))
+	})
+	mux.HandleFunc("/", func(http.ResponseWriter, *http.Request) {
+		<-release
+	})
+
+	server := httptest.NewServer(mux)
+	// cleanups run LIFO: release the frozen handlers first, so server.Close
+	// does not wait on requests that never answer.
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(release) })
+
+	return server
+}
+
+// shortenDeliveryDeadlines swaps the outbound clients of the inform run for a
+// short deadline - including the daily sentence behind a frozen endpoint - and
+// returns one restore covering all of them, so a frozen request fails within
+// the test instead of parking it for the full production minute.
+func shortenDeliveryDeadlines(frozenSoupURL string) func() {
+	short := &http.Client{Timeout: 100 * time.Millisecond}
+
+	restoreLark := lark.SetClientForTest(short)
+	restoreDing := ding.SetClientForTest(short)
+	restoreSoupClient := soup.SetClientForTest(short)
+	restoreSoupURL := soup.SetURLForTest(frozenSoupURL)
+
+	return func() {
+		restoreLark()
+		restoreDing()
+		restoreSoupClient()
+		restoreSoupURL()
+	}
+}
+
+func TestTriggerNowReleasesTheGuardAfterAFrozenLarkWebhook(t *testing.T) {
+	assertFrozenTriggerReleasesTheGuard(t, "/feishu.cn/hang", "/feishu.cn/ok")
+}
+
+func TestTriggerNowReleasesTheGuardAfterAFrozenDingWebhook(t *testing.T) {
+	assertFrozenTriggerReleasesTheGuard(t, "/dingtalk.com/hang", "/dingtalk.com/ok")
+}
+
+// assertFrozenTriggerReleasesTheGuard proves the failure mode behind the
+// permanent "already in progress" fault: a webhook that never answers must
+// fail the run within the client deadline, release the process guard on the
+// way out, and leave the next manual push free to run at once.
+func assertFrozenTriggerReleasesTheGuard(t *testing.T, frozenPath, healthyPath string) {
+	t.Helper()
+
+	server := frozenBotServer(t)
+	app := newTestApp(t)
+
+	require.NoError(t, app.SaveConfig(validFeedDTO()))
+	require.NoError(t, app.SaveWebhook(server.URL+frozenPath))
+
+	restore := shortenDeliveryDeadlines(server.URL)
+	defer restore()
+
+	start := time.Now()
+	result, err := app.TriggerNow()
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "a frozen webhook is a run failure, not a binding failure")
+	require.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.False(t, result.Notified)
+	assert.NotEmpty(t, result.ErrorInfo)
+	assert.Less(t, elapsed, 30*time.Second, "the client deadline must bound a frozen webhook")
+	assert.FileExists(t, result.ContentFilePath, "the daily file survives a failed delivery")
+
+	// the frozen run must have released the guard on its way out: with a
+	// healthy webhook the very next push runs at once instead of failing with
+	// ErrInformRunning until a restart.
+	require.NoError(t, app.SaveWebhook(server.URL+healthyPath))
+
+	next, err := app.TriggerNow()
+	require.NotErrorIs(t, err, ErrInformRunning, "a failed run must free the guard")
+	require.NoError(t, err)
+	require.NotNil(t, next)
+	assert.True(t, next.Success)
+	assert.True(t, next.Notified)
+}

--- a/internal/ding/dingding.go
+++ b/internal/ding/dingding.go
@@ -26,12 +26,30 @@ import (
 	"time"
 
 	"github.com/vogo/logger"
+
+	"github.com/vogo/informer/internal/httpx"
 )
 
 const Host = "dingtalk.com"
 
 // ErrDingResponse marks a dingtalk bot answering with a non successful status.
 var ErrDingResponse = errors.New("ding response error")
+
+// client delivers the webhook request. It is the shared httpx client whose 60s
+// timeout turns a hung connection into a delivery failure, so one frozen bot
+// can never occupy the inform run forever. It is a variable so tests can
+// shorten the deadline without touching the production default.
+var client = httpx.HTTPClient
+
+// SetClientForTest swaps the delivery client and returns a restore function.
+// It is the seam the timeout tests use to fail a frozen webhook in
+// milliseconds instead of waiting out the full production deadline.
+func SetClientForTest(c *http.Client) func() {
+	previous := client
+	client = c
+
+	return func() { client = previous }
+}
 
 type MsgText struct {
 	Content string `json:"content"`
@@ -70,7 +88,7 @@ func Ding(url, content, user string, weekday time.Weekday) error {
 	logger.Infof("ding url: %s", url)
 	logger.Infof("ding data: %s", data)
 
-	resp, err := http.Post(url, "application/json", bytes.NewReader(data))
+	resp, err := client.Post(url, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("post ding message: %w", err)
 	}

--- a/internal/ding/dingding_test.go
+++ b/internal/ding/dingding_test.go
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ding_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/ding"
+)
+
+// frozenServer never answers a request until the test ends, the shape of a
+// webhook that accepted the connection and then hung.
+func frozenServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	release := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release
+	}))
+	// cleanups run LIFO: release the frozen handler first, so server.Close
+	// does not wait on a request that never answers.
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(release) })
+
+	return server
+}
+
+func TestDingDeliversToAnAcceptingBot(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"errcode":0}`))
+	}))
+	defer server.Close()
+
+	require.NoError(t, ding.Ding(server.URL, "content", "", time.Monday))
+}
+
+func TestDingReportsARejectedMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bot rejected the message", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	err := ding.Ding(server.URL, "content", "", time.Monday)
+	require.ErrorIs(t, err, ding.ErrDingResponse, "a non successful status stays a bot rejection")
+}
+
+// TestDingFailsAFrozenWebhookWithinTheTimeout covers the stuck lock root cause:
+// a webhook that hangs must fail the delivery within the client deadline
+// instead of blocking the inform run forever.
+func TestDingFailsAFrozenWebhookWithinTheTimeout(t *testing.T) {
+	server := frozenServer(t)
+
+	restore := ding.SetClientForTest(&http.Client{Timeout: 100 * time.Millisecond})
+	defer restore()
+
+	start := time.Now()
+	err := ding.Ding(server.URL, "content", "", time.Monday)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a frozen webhook must surface as a delivery failure")
+	require.ErrorContains(t, err, "post ding message")
+	require.NotErrorIs(t, err, ding.ErrDingResponse, "a timeout is not a bot rejection")
+	assert.Less(t, elapsed, 30*time.Second, "the client deadline must bound a frozen webhook")
+}

--- a/internal/feed/gofeed.go
+++ b/internal/feed/gofeed.go
@@ -24,11 +24,17 @@ import (
 	"github.com/mmcdole/gofeed"
 	"github.com/vogo/logger"
 	"github.com/vogo/vogo/vnet/vurl"
+
+	"github.com/vogo/informer/internal/httpx"
 )
 
 // ParseGoFeed parse feed.
 func ParseGoFeed(source *Source) (*gofeed.Feed, error) {
 	fp := gofeed.NewParser()
+	// bound the fetch with the shared 60s client: the parser default has no
+	// timeout, so a source that accepts the connection but never answers would
+	// otherwise park the inform run, and its lock, forever.
+	fp.Client = httpx.HTTPClient
 
 	feed, err := fp.ParseURL(source.URL)
 	if err != nil {

--- a/internal/lark/lark.go
+++ b/internal/lark/lark.go
@@ -25,12 +25,30 @@ import (
 	"net/http"
 
 	"github.com/vogo/logger"
+
+	"github.com/vogo/informer/internal/httpx"
 )
 
 const Host = "feishu.cn"
 
 // ErrLarkResponse marks a lark bot answering with a non successful status.
 var ErrLarkResponse = errors.New("lark response error")
+
+// client delivers the webhook request. It is the shared httpx client whose 60s
+// timeout turns a hung connection into a delivery failure, so one frozen bot
+// can never occupy the inform run forever. It is a variable so tests can
+// shorten the deadline without touching the production default.
+var client = httpx.HTTPClient
+
+// SetClientForTest swaps the delivery client and returns a restore function.
+// It is the seam the timeout tests use to fail a frozen webhook in
+// milliseconds instead of waiting out the full production deadline.
+func SetClientForTest(c *http.Client) func() {
+	previous := client
+	client = c
+
+	return func() { client = previous }
+}
 
 type Content struct {
 	Text string `json:"text"`
@@ -60,7 +78,7 @@ func Lark(url, content string) error {
 	logger.Infof("lark url: %s", url)
 	logger.Infof("lark data: %s", data)
 
-	resp, err := http.Post(url, "application/json", bytes.NewReader(data))
+	resp, err := client.Post(url, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("post lark message: %w", err)
 	}

--- a/internal/lark/lark_test.go
+++ b/internal/lark/lark_test.go
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lark_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/lark"
+)
+
+// frozenServer never answers a request until the test ends, the shape of a
+// webhook that accepted the connection and then hung.
+func frozenServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	release := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release
+	}))
+	// cleanups run LIFO: release the frozen handler first, so server.Close
+	// does not wait on a request that never answers.
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(release) })
+
+	return server
+}
+
+func TestLarkDeliversToAnAcceptingBot(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"code":0}`))
+	}))
+	defer server.Close()
+
+	require.NoError(t, lark.Lark(server.URL, "content"))
+}
+
+func TestLarkReportsARejectedMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "bot rejected the message", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	err := lark.Lark(server.URL, "content")
+	require.ErrorIs(t, err, lark.ErrLarkResponse, "a non successful status stays a bot rejection")
+}
+
+// TestLarkFailsAFrozenWebhookWithinTheTimeout covers the stuck lock root cause:
+// a webhook that hangs must fail the delivery within the client deadline
+// instead of blocking the inform run forever.
+func TestLarkFailsAFrozenWebhookWithinTheTimeout(t *testing.T) {
+	server := frozenServer(t)
+
+	restore := lark.SetClientForTest(&http.Client{Timeout: 100 * time.Millisecond})
+	defer restore()
+
+	start := time.Now()
+	err := lark.Lark(server.URL, "content")
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a frozen webhook must surface as a delivery failure")
+	require.ErrorContains(t, err, "post lark message")
+	require.NotErrorIs(t, err, lark.ErrLarkResponse, "a timeout is not a bot rejection")
+	assert.Less(t, elapsed, 30*time.Second, "the client deadline must bound a frozen webhook")
+}

--- a/internal/service/inform_test.go
+++ b/internal/service/inform_test.go
@@ -18,13 +18,20 @@
 package service_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/ding"
 	"github.com/vogo/informer/internal/feed"
+	"github.com/vogo/informer/internal/lark"
 	"github.com/vogo/informer/internal/service"
+	"github.com/vogo/informer/internal/soup"
 )
 
 // allArticles reads every stored article, ordered by id.
@@ -169,4 +176,119 @@ func TestTriggerInformWithoutConfigFile(t *testing.T) {
 
 	_, err = svc.TriggerInform("")
 	require.ErrorContains(t, err, "read config file")
+}
+
+// frozenServer never answers a request until the test ends, the shape of a
+// webhook that accepted the connection and then hung.
+func frozenServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	release := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release
+	}))
+	// cleanups run LIFO: release the frozen handler first, so server.Close
+	// does not wait on a request that never answers.
+	t.Cleanup(server.Close)
+	t.Cleanup(func() { close(release) })
+
+	return server
+}
+
+// freezeDailySoup points the daily sentence at a frozen endpoint behind a short
+// deadline, so the run under test never depends on the public endpoint and the
+// soup step degrades in milliseconds instead of minutes.
+func freezeDailySoup(t *testing.T, url string) {
+	t.Helper()
+
+	restoreURL := soup.SetURLForTest(url)
+	restoreClient := soup.SetClientForTest(&http.Client{Timeout: 100 * time.Millisecond})
+
+	t.Cleanup(restoreURL)
+	t.Cleanup(restoreClient)
+}
+
+// TestTriggerInformFailsWhenTheLarkWebhookFreezes covers the stuck lock root
+// cause end to end: a lark webhook that hangs must fail the whole run within
+// the client deadline, keep the daily file, and leave the articles unrecorded
+// so the scheduler retries the day on its next tick.
+func TestTriggerInformFailsWhenTheLarkWebhookFreezes(t *testing.T) {
+	server := newContentServer(t)
+	frozen := frozenServer(t)
+	svc := newService(t)
+
+	require.NoError(t, svc.CreateSource(feedSource(server)))
+	freezeDailySoup(t, frozen.URL)
+
+	restore := lark.SetClientForTest(&http.Client{Timeout: 100 * time.Millisecond})
+	defer restore()
+
+	start := time.Now()
+	result, err := svc.TriggerInform(frozen.URL + "/feishu.cn/hang")
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a frozen webhook must fail the run")
+	require.NotNil(t, result)
+	assert.False(t, result.Notified)
+	assert.Less(t, elapsed, 30*time.Second, "the client deadline must bound a frozen webhook")
+	assert.FileExists(t, result.ContentFilePath, "the daily file survives a failed delivery")
+
+	for _, article := range allArticles(t, svc) {
+		assert.Nil(t, article.InformedAt, "a failed delivery must not be recorded as informed")
+	}
+
+	// the failure is a terminal result, not a wedged state: with a healthy
+	// webhook, the very next run succeeds instead of staying blocked.
+	result, err = svc.TriggerInform(server.URL + "/feishu.cn/ok")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Notified)
+}
+
+// TestTriggerInformFailsWhenTheDingWebhookFreezes repeats the frozen webhook
+// proof for the dingtalk channel.
+func TestTriggerInformFailsWhenTheDingWebhookFreezes(t *testing.T) {
+	server := newContentServer(t)
+	frozen := frozenServer(t)
+	svc := newService(t)
+
+	require.NoError(t, svc.CreateSource(feedSource(server)))
+	freezeDailySoup(t, frozen.URL)
+
+	restore := ding.SetClientForTest(&http.Client{Timeout: 100 * time.Millisecond})
+	defer restore()
+
+	start := time.Now()
+	result, err := svc.TriggerInform(frozen.URL + "/dingtalk.com/hang")
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a frozen webhook must fail the run")
+	require.NotNil(t, result)
+	assert.False(t, result.Notified)
+	assert.Less(t, elapsed, 30*time.Second, "the client deadline must bound a frozen webhook")
+	assert.FileExists(t, result.ContentFilePath, "the daily file survives a failed delivery")
+
+	for _, article := range allArticles(t, svc) {
+		assert.Nil(t, article.InformedAt, "a failed delivery must not be recorded as informed")
+	}
+}
+
+// TestTriggerInformSucceedsWhenTheDailySoupFreezes proves the soup deadline is
+// a degradation only: the fetch, the daily file and the bot delivery all
+// survive a frozen daily sentence endpoint.
+func TestTriggerInformSucceedsWhenTheDailySoupFreezes(t *testing.T) {
+	server := newContentServer(t)
+	frozen := frozenServer(t)
+	svc := newService(t)
+
+	require.NoError(t, svc.CreateSource(feedSource(server)))
+	freezeDailySoup(t, frozen.URL)
+
+	result, err := svc.TriggerInform(server.URL + "/feishu.cn/ok")
+	require.NoError(t, err, "a frozen daily sentence must not fail the run")
+	require.NotNil(t, result)
+	assert.True(t, result.Notified)
+	assert.Len(t, result.Articles, 2)
+	assert.FileExists(t, result.ContentFilePath)
 }

--- a/internal/soup/soup.go
+++ b/internal/soup/soup.go
@@ -23,10 +23,41 @@ import (
 	"net/http"
 
 	"github.com/vogo/logger"
+
+	"github.com/vogo/informer/internal/httpx"
 )
 
+// dailyURL is the endpoint of the daily sentence. It is a variable so tests
+// can aim the fetch at a local server instead of the public one.
+var dailyURL = "http://open.iciba.com/dsapi/"
+
+// client fetches the daily sentence. It is the shared httpx client whose 60s
+// timeout turns a hung connection into the empty fallback, so a frozen
+// endpoint can never occupy the inform run forever. It is a variable so tests
+// can shorten the deadline without touching the production default.
+var client = httpx.HTTPClient
+
+// SetClientForTest swaps the fetch client and returns a restore function.
+// It is the seam the timeout tests use to degrade a frozen endpoint in
+// milliseconds instead of waiting out the full production deadline.
+func SetClientForTest(c *http.Client) func() {
+	previous := client
+	client = c
+
+	return func() { client = previous }
+}
+
+// SetURLForTest swaps the daily sentence endpoint and returns a restore
+// function, so tests can hermetically exercise the fetch and its fallback.
+func SetURLForTest(url string) func() {
+	previous := dailyURL
+	dailyURL = url
+
+	return func() { dailyURL = previous }
+}
+
 func GetDailySoup() string {
-	resp, err := http.Get("http://open.iciba.com/dsapi/")
+	resp, err := client.Get(dailyURL)
 	if err != nil {
 		logger.Infof("err: %v", err)
 

--- a/internal/soup/soup_test.go
+++ b/internal/soup/soup_test.go
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package soup_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/soup"
+)
+
+func TestGetDailySoupReturnsTheContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"content":"hello soup"}`))
+	}))
+	defer server.Close()
+
+	restore := soup.SetURLForTest(server.URL)
+	defer restore()
+
+	require.Equal(t, "hello soup", soup.GetDailySoup())
+}
+
+func TestGetDailySoupDegradesOnARejectedRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	restore := soup.SetURLForTest(server.URL)
+	defer restore()
+
+	require.Empty(t, soup.GetDailySoup(), "a non successful status degrades to empty")
+}
+
+func TestGetDailySoupDegradesOnInvalidContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not a json document"))
+	}))
+	defer server.Close()
+
+	restore := soup.SetURLForTest(server.URL)
+	defer restore()
+
+	require.Empty(t, soup.GetDailySoup(), "an unparsable body degrades to empty")
+}
+
+// TestGetDailySoupDegradesWhenTheEndpointFreezes covers the pre-delivery hang:
+// a frozen endpoint must degrade to empty within the client deadline instead
+// of occupying the inform run forever.
+func TestGetDailySoupDegradesWhenTheEndpointFreezes(t *testing.T) {
+	release := make(chan struct{})
+
+	frozen := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release
+	}))
+	// cleanups run LIFO: release the frozen handler first, so frozen.Close
+	// does not wait on a request that never answers.
+	t.Cleanup(frozen.Close)
+	t.Cleanup(func() { close(release) })
+
+	restoreURL := soup.SetURLForTest(frozen.URL)
+	defer restoreURL()
+
+	restoreClient := soup.SetClientForTest(&http.Client{Timeout: 100 * time.Millisecond})
+	defer restoreClient()
+
+	start := time.Now()
+	content := soup.GetDailySoup()
+	elapsed := time.Since(start)
+
+	assert.Empty(t, content, "a frozen endpoint degrades to empty")
+	assert.Less(t, elapsed, 30*time.Second, "the client deadline must bound a frozen endpoint")
+}


### PR DESCRIPTION
## Why

桌面版「设置 → 手动推送 → 立即推送」与定时推送共用进程锁 `informMu`。钉钉/飞书 webhook 用裸 `http.Post`、每日一句用裸 `http.Get`,均无超时:webhook 一旦挂死,该次 run 永不结束、锁被永久占用,此后每次手动推送都报 `an inform run is already in progress, try again in a moment`,只能重启恢复。

## What

- 钉钉/飞书/每日一句出站请求切换到 `internal/httpx` 共享客户端(`Timeout = httpx.DefaultRequestTimeout`,60s),挂死的推送在有限时间内以失败收敛,run 正常退出并释放锁(`defer informMu.Unlock()` 覆盖所有失败路径,已核实)
- 顺带排查:订阅抓取的 gofeed 解析器默认客户端同样无超时且在持锁区内,一并设为共享客户端(json/regex 抓取走 `httpx.GetLinkData` 已有超时;外部依赖 `vurl.RedirectURL` 亦无超时,属外部模块,未动)
- 测试缝隙:`ding`/`lark` 导出 `SetClientForTest`,`soup` 导出 `SetClientForTest`/`SetURLForTest`,均返回还原函数;生产默认值不变、无新增配置项

## Verification

- 飞书/钉钉分别模拟 webhook 挂死:run 在超时内失败返回、`Notified=false`、日报文件保留、`informed_at` 不打标,随后立即再触发 `TriggerNow` 不再报 "already in progress"(新增 `binding_inform_timeout_test.go`,两机器人各一例)
- 每日一句挂死降级为空,整次 inform 继续并推送成功
- 正常投递、无 webhook、机器人拒绝、`Notified=true` 与 `informed_at` 打标等既有用例全部继续通过;真实并发撞车仍立即返回 `ErrInformRunning`(保护机器人消息不重复发送,行为刻意保持不变)
- 两模块 `go test ./...` 全绿(含 `-race` 覆盖新增包),golangci-lint 改动文件无新增问题,license header / `CGO_ENABLED=0` CLI 构建检查通过

无 UI/文案/文档变更(行为契约未变,仅修复挂死缺陷)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)