### PR TITLE
feat(release): publish a SHA256 checksum manifest with release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,21 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      # the manifest is hashed and written outside artifacts/ and only then
+      # moved in, so it can never list itself no matter how the shell orders
+      # the redirect against the glob. An empty download fails the job here
+      # rather than shipping a hollow manifest.
+      - name: Generate SHA256 checksums
+        shell: bash
+        run: |
+          checksums="informer-ui-${{ github.ref_name }}-checksums-sha256.txt"
+          cd artifacts
+          mapfile -t assets < <(find . -maxdepth 1 -type f -printf '%P\n' | sort)
+          test "${#assets[@]}" -gt 0
+          sha256sum "${assets[@]}" > "${RUNNER_TEMP}/${checksums}"
+          cat "${RUNNER_TEMP}/${checksums}"
+          mv "${RUNNER_TEMP}/${checksums}" .
+
       - name: List release assets
         run: ls -la artifacts
 


### PR DESCRIPTION
## 背景

`release.yml` 在打 `v*` tag 时发布四类产物（macOS dmg / Windows NSIS setup / Linux tar.gz / Linux deb），但项目当前阶段明确不做代码签名与公证。用户下载后没有任何手段判断安装包是否在传输或中间环节被损坏、被替换 —— hash 校验文件因此是用户侧唯一可用的完整性基线。

## 改动

只在 `publish` 聚合 job 中新增一步（13 行），落在「Download all release artifacts」之后、「Create or update release」之前：

```yaml
- name: Generate SHA256 checksums
  shell: bash
  run: |
    checksums="informer-ui-${{ github.ref_name }}-checksums-sha256.txt"
    cd artifacts
    mapfile -t assets < <(find . -maxdepth 1 -type f -printf '%P\n' | sort)
    test "${#assets[@]}" -gt 0
    sha256sum "${assets[@]}" > "${RUNNER_TEMP}/${checksums}"
    cat "${RUNNER_TEMP}/${checksums}"
    mv "${RUNNER_TEMP}/${checksums}" .
```

校验文件写入 `artifacts/`，由既有的 `files: artifacts/*` glob 自动带上，**不新增任何发布配置**。

设计要点：

- **不自指** —— 在 `RUNNER_TEMP` 里算完再 `mv` 进 `artifacts/`，不依赖「重定向与 glob 展开孰先孰后」这类隐式行为。
- **失败要响** —— `shell: bash` 带来 `-eo pipefail`，`test "${#assets[@]}" -gt 0` 兜住空目录，宁可让 job 失败也不发布残缺清单。
- **basename 无路径前缀** —— `cd artifacts` + `find -printf '%P\n'` 保证清单里只有文件名，用户下载到同一目录后可直接 `sha256sum -c` 验证；`sort` 让重跑时清单顺序稳定。

三个平台 job 的构建与上传逻辑、发布触发条件（仍为 `v*` tag）、Release 的创建/更新语义均**未改动**。

## 验证

本地为 bash 3.2 + BSD find，跑不了这段 GNU 语法，故在 `ubuntu:24.04`（与 runner 同镜像）中实跑。**步骤脚本体是从 `release.yml` 中程序化提取的 verbatim 内容**，不是手抄，以避免与实际 workflow 漂移。

```
=== step exit code: 0 ===
PASS: step succeeds with 4 artifacts
PASS: checksum file lands in artifacts/
PASS: no temp leftover
PASS: exactly 4 lines
PASS: manifest excludes itself
PASS: all lines are '<sha256>  <basename>'
PASS: manifest covers exactly the 4 assets
=== sha256sum -c output ===
informer-ui-v9.9.9-test-darwin-universal.dmg: OK
informer-ui-v9.9.9-test-linux-amd64.deb: OK
informer-ui-v9.9.9-test-linux-amd64.tar.gz: OK
informer-ui-v9.9.9-test-windows-amd64-setup.exe: OK
=== sha256sum -c exit code: 0 ===
PASS: sha256sum -c passes with exit 0
PASS: tampered asset detected
PASS: empty artifacts/ fails the step (exit 1)
PASS: no manifest written on empty dir
ALL CHECKS PASSED
```

`actionlint`（内含 shellcheck）对整个 `release.yml` 零告警，退出码 0。

**未覆盖**：上述测试用的是同名假产物，真实产物的 Release 全流程无法在本地验证。剩余风险很低（该步骤只依赖 `artifacts/` 内有文件，与文件内容无关），但正式发版前建议先打一个测试 tag 跑通一遍。

## 非目标

不对校验文件做 GPG / Minisign 签名（沿用既有「不做签名 / 公证」决策）；不做每平台各自的校验文件；不引入 GoReleaser；不追求可复现构建 —— 同 tag 重跑的哈希可以不同，校验文件只需与当次产物一致；README 的下载校验用法文档留待后续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)