### PR TITLE
feat(ui): 订阅页左侧栏支持按来源类型、抓取状态、启停状态过滤

### DIFF
--- a/cmd/informer-ui/binding.go
+++ b/cmd/informer-ui/binding.go
@@ -114,16 +114,57 @@ func toSourceDTO(source *feed.Source) *SourceDTO {
 	}
 }
 
-// ListSources returns the subscriptions of one category ordered by id, or every
-// subscription when categoryID is zero. The result is never nil so an empty
-// database renders as an empty list, not a failure.
-func (a *App) ListSources(categoryID int64) ([]*SourceDTO, error) {
+// Enabled states a subscription listing can be restricted to. The tri state is
+// spelled out instead of sent as a nullable boolean, because the sidebar has to
+// distinguish "no opinion" from "explicitly disabled" across the json boundary.
+const (
+	EnabledStateOn  = "enabled"
+	EnabledStateOff = "disabled"
+)
+
+// SourceQueryRequest is the filter snapshot the subscription page submits. Every
+// field is optional and an empty one drops that dimension; the filled ones are
+// combined with AND. An unknown value is a reported error rather than a
+// silently unfiltered list, so a stale frontend cannot claim a filter took hold.
+type SourceQueryRequest struct {
+	// CategoryID restricts the listing to one category, zero means every category.
+	CategoryID int64 `json:"categoryId"`
+
+	// ParseType is one of SupportedParseTypes and matches the resolved type -
+	// the same value SourceDTO.ResolvedParseType carries and the card shows.
+	ParseType string `json:"parseType"`
+
+	// FetchStatus is "normal", "error" or "unfetched".
+	FetchStatus string `json:"fetchStatus"`
+
+	// EnabledState is EnabledStateOn or EnabledStateOff.
+	EnabledState string `json:"enabledState"`
+}
+
+// SupportedParseTypes returns the parse types a subscription can be filtered by,
+// in presentation order. It answers from the parser set itself, so a sidebar
+// built from this list offers exactly the types the query accepts. It reads no
+// database and therefore stays available while the app reports a startup error.
+func (a *App) SupportedParseTypes() []string {
+	return feed.LegalParseTypes()
+}
+
+// ListSources returns the subscriptions matching the filter snapshot, ordered by
+// id. A nil request lists every subscription. The result is never nil so an
+// empty database - or a filter nothing matches - renders as an empty list,
+// not a failure.
+func (a *App) ListSources(req *SourceQueryRequest) ([]*SourceDTO, error) {
 	err := a.ready()
 	if err != nil {
 		return nil, err
 	}
 
-	sources, err := a.svc.AllSources(service.SourceQuery{CategoryID: categoryID})
+	query, err := toSourceQuery(req)
+	if err != nil {
+		return nil, err
+	}
+
+	sources, err := a.svc.AllSources(query)
 	if err != nil {
 		return nil, err
 	}
@@ -134,6 +175,36 @@ func (a *App) ListSources(categoryID int64) ([]*SourceDTO, error) {
 	}
 
 	return dtos, nil
+}
+
+// toSourceQuery maps the frontend filter snapshot onto the service query. The
+// parse type and the fetch status pass through untouched: the service owns their
+// vocabulary and rejects an unknown value there, in one place.
+func toSourceQuery(req *SourceQueryRequest) (service.SourceQuery, error) {
+	if req == nil {
+		return service.SourceQuery{}, nil
+	}
+
+	query := service.SourceQuery{
+		CategoryID:  req.CategoryID,
+		ParseType:   req.ParseType,
+		FetchStatus: req.FetchStatus,
+	}
+
+	switch req.EnabledState {
+	case "":
+	case EnabledStateOn:
+		enabled := true
+		query.Enabled = &enabled
+	case EnabledStateOff:
+		disabled := false
+		query.Enabled = &disabled
+	default:
+		return service.SourceQuery{},
+			fmt.Errorf("%w: unknown enabled state %q", service.ErrInvalidArgument, req.EnabledState)
+	}
+
+	return query, nil
 }
 
 // CreateSource stores a new subscription and returns the stored record.

--- a/cmd/informer-ui/binding_manage_test.go
+++ b/cmd/informer-ui/binding_manage_test.go
@@ -102,7 +102,7 @@ func TestDeleteCategoryReportsUseBeforeMoving(t *testing.T) {
 	assert.True(t, done.Deleted)
 	assert.Equal(t, int64(1), done.Moved)
 
-	sources, err := app.ListSources(0)
+	sources, err := app.ListSources(nil)
 	require.NoError(t, err)
 	require.Len(t, sources, 1)
 	assert.Equal(t, source.ID, sources[0].ID)
@@ -132,11 +132,11 @@ func TestListSourcesFiltersByCategory(t *testing.T) {
 	_, err = app.CreateSource(elsewhere)
 	require.NoError(t, err)
 
-	all, err := app.ListSources(0)
+	all, err := app.ListSources(nil)
 	require.NoError(t, err)
 	assert.Len(t, all, 2)
 
-	filtered, err := app.ListSources(tech.ID)
+	filtered, err := app.ListSources(&SourceQueryRequest{CategoryID: tech.ID})
 	require.NoError(t, err)
 	require.Len(t, filtered, 1)
 	assert.Equal(t, "in tech", filtered[0].Title)
@@ -145,9 +145,163 @@ func TestListSourcesFiltersByCategory(t *testing.T) {
 	empty, err := app.CreateCategory(&SaveCategoryRequest{Name: "empty"})
 	require.NoError(t, err)
 
-	none, err := app.ListSources(empty.ID)
+	none, err := app.ListSources(&SourceQueryRequest{CategoryID: empty.ID})
 	require.NoError(t, err)
 	assert.Empty(t, none)
+	assert.NotNil(t, none, "a filter nothing matches is an empty list, not a nil one")
+}
+
+// titlesOf flattens a listing the way the subscription page renders it: the set
+// of cards left visible under the current filter.
+func titlesOf(sources []*SourceDTO) []string {
+	titles := make([]string, 0, len(sources))
+	for _, source := range sources {
+		titles = append(titles, source.Title)
+	}
+
+	return titles
+}
+
+// The filter vocabulary and the seeded titles the listing cases share.
+const (
+	parseTypeFeed = "feed"
+	parseTypeJSON = "json"
+
+	fetchStatusUnfetched = "unfetched"
+
+	titleLegacyJSON   = "legacy json"
+	titleExplicitFeed = "explicit feed"
+	titleDisabled     = "disabled feed"
+)
+
+// seedFilterSources stores the three subscriptions the filter cases share and
+// returns the category two of them belong to.
+func seedFilterSources(t *testing.T, app *App) int64 {
+	t.Helper()
+
+	tech, err := app.CreateCategory(&SaveCategoryRequest{Name: techName})
+	require.NoError(t, err)
+
+	// a record whose type is only derivable from the legacy json flag, exactly
+	// what a subscription stored before the parse type column looked like.
+	legacy := sampleRequest()
+	legacy.Title = titleLegacyJSON
+	legacy.URL = "https://a.example.com/data.json"
+	legacy.ParseType = ""
+	legacy.IsJSON = true
+	legacy.CategoryID = tech.ID
+
+	legacyRecord, err := app.CreateSource(legacy)
+	require.NoError(t, err)
+	assert.Empty(t, legacyRecord.ParseType)
+	//nolint:testifylint //a parse type name is not an encoded json payload.
+	assert.Equal(t, parseTypeJSON, legacyRecord.ResolvedParseType, "the card labels it json")
+
+	explicit := sampleRequest()
+	explicit.Title = titleExplicitFeed
+	explicit.URL = "https://b.example.com/atom.xml"
+	explicit.CategoryID = tech.ID
+
+	_, err = app.CreateSource(explicit)
+	require.NoError(t, err)
+
+	disabled := sampleRequest()
+	disabled.Title = titleDisabled
+	disabled.URL = "https://c.example.com/atom.xml"
+
+	disabledSource, err := app.CreateSource(disabled)
+	require.NoError(t, err)
+	require.NoError(t, app.SetSourceEnabled(disabledSource.ID, false))
+
+	return tech.ID
+}
+
+func TestSupportedParseTypesFeedsTheFilter(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApp(t)
+
+	types := app.SupportedParseTypes()
+	assert.Equal(t, []string{parseTypeFeed, "regex", parseTypeJSON}, types)
+
+	// the sidebar builds its options from this list alone, so every entry has to
+	// be a value the listing accepts.
+	for _, parseType := range types {
+		_, err := app.ListSources(&SourceQueryRequest{ParseType: parseType})
+		require.NoError(t, err, "parse type %q", parseType)
+	}
+
+	// it is static metadata, so it keeps answering when the service never started.
+	broken := newAppWithHome(filepath.Join(t.TempDir(), "missing", "nested"))
+	require.NotEmpty(t, broken.StartupError())
+	assert.Equal(t, types, broken.SupportedParseTypes())
+}
+
+func TestListSourcesFiltersByParseTypeAndFetchStatus(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApp(t)
+	seedFilterSources(t, app)
+
+	// selecting json finds the record that carries no parse type at all.
+	jsonOnly, err := app.ListSources(&SourceQueryRequest{ParseType: parseTypeJSON})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleLegacyJSON}, titlesOf(jsonOnly))
+
+	feedOnly, err := app.ListSources(&SourceQueryRequest{ParseType: parseTypeFeed})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleExplicitFeed, titleDisabled}, titlesOf(feedOnly))
+
+	// no subscription has been fetched yet, so all three share one bucket.
+	unfetched, err := app.ListSources(&SourceQueryRequest{FetchStatus: fetchStatusUnfetched})
+	require.NoError(t, err)
+	assert.Len(t, unfetched, 3)
+
+	failed, err := app.ListSources(&SourceQueryRequest{FetchStatus: "error"})
+	require.NoError(t, err)
+	assert.Empty(t, failed)
+}
+
+func TestListSourcesFiltersByEnabledStateAndCombination(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApp(t)
+	techID := seedFilterSources(t, app)
+
+	enabledOnly, err := app.ListSources(&SourceQueryRequest{EnabledState: EnabledStateOn})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleLegacyJSON, titleExplicitFeed}, titlesOf(enabledOnly))
+
+	disabledOnly, err := app.ListSources(&SourceQueryRequest{EnabledState: EnabledStateOff})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleDisabled}, titlesOf(disabledOnly))
+
+	// every dimension at once narrows to the single record satisfying all of them.
+	combined, err := app.ListSources(&SourceQueryRequest{
+		CategoryID:   techID,
+		ParseType:    parseTypeFeed,
+		FetchStatus:  fetchStatusUnfetched,
+		EnabledState: EnabledStateOn,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleExplicitFeed}, titlesOf(combined))
+}
+
+func TestListSourcesRejectsUnknownFilterValues(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApp(t)
+
+	// an unknown enum is reported, so a stale frontend can never be shown an
+	// unfiltered list while its sidebar claims a filter is active.
+	_, err := app.ListSources(&SourceQueryRequest{ParseType: "agent"})
+	require.ErrorIs(t, err, service.ErrInvalidArgument)
+
+	_, err = app.ListSources(&SourceQueryRequest{FetchStatus: "broken"})
+	require.ErrorIs(t, err, service.ErrInvalidArgument)
+
+	_, err = app.ListSources(&SourceQueryRequest{EnabledState: "paused"})
+	require.ErrorIs(t, err, service.ErrInvalidArgument)
 }
 
 func TestDailyBindings(t *testing.T) {

--- a/cmd/informer-ui/binding_test.go
+++ b/cmd/informer-ui/binding_test.go
@@ -61,7 +61,7 @@ func TestSourceCRUD(t *testing.T) {
 
 	app := newTestApp(t)
 
-	empty, err := app.ListSources(0)
+	empty, err := app.ListSources(nil)
 	require.NoError(t, err)
 	assert.Empty(t, empty)
 
@@ -72,7 +72,7 @@ func TestSourceCRUD(t *testing.T) {
 	assert.Equal(t, int64(1), created.CategoryID, "the service assigns the default category")
 	assert.Equal(t, "feed", created.ResolvedParseType)
 
-	listed, err := app.ListSources(0)
+	listed, err := app.ListSources(nil)
 	require.NoError(t, err)
 	require.Len(t, listed, 1)
 	assert.Equal(t, created.ID, listed[0].ID)
@@ -89,14 +89,14 @@ func TestSourceCRUD(t *testing.T) {
 
 	require.NoError(t, app.SetSourceEnabled(created.ID, false))
 
-	listed, err = app.ListSources(0)
+	listed, err = app.ListSources(nil)
 	require.NoError(t, err)
 	require.Len(t, listed, 1)
 	assert.False(t, listed[0].Enabled)
 
 	require.NoError(t, app.DeleteSource(created.ID))
 
-	empty, err = app.ListSources(0)
+	empty, err = app.ListSources(nil)
 	require.NoError(t, err)
 	assert.Empty(t, empty)
 
@@ -149,7 +149,7 @@ func TestPreviewParsesWithoutWriting(t *testing.T) {
 	assert.Equal(t, "Hello Preview", articles[0].Title)
 	assert.Equal(t, "https://example.com/one", articles[0].URL)
 
-	listed, err := app.ListSources(0)
+	listed, err := app.ListSources(nil)
 	require.NoError(t, err)
 	require.Len(t, listed, 1)
 	assert.Equal(t, 0, listed[0].Status, "a preview leaves the source health untouched")
@@ -163,6 +163,6 @@ func TestStartupFailureSurfaces(t *testing.T) {
 
 	assert.NotEmpty(t, app.StartupError())
 
-	_, err := app.ListSources(0)
+	_, err := app.ListSources(nil)
 	assert.ErrorIs(t, err, ErrNotReady)
 }

--- a/cmd/informer-ui/frontend/src/ArticleLibrary.vue
+++ b/cmd/informer-ui/frontend/src/ArticleLibrary.vue
@@ -49,7 +49,12 @@ onMounted(async () => {
 
 async function loadFilters() {
   try {
-    const [categories, sources] = await Promise.all([ListCategories(), ListSources(0)])
+    // the article library names every subscription that ever produced an
+    // article, so it asks for the unfiltered set on purpose.
+    const [categories, sources] = await Promise.all([
+      ListCategories(),
+      ListSources({categoryId: 0, parseType: '', fetchStatus: '', enabledState: ''})
+    ])
 
     categoryOptions.value = [
       {label: '全部分类', value: 0},

--- a/cmd/informer-ui/frontend/src/CategoryPanel.vue
+++ b/cmd/informer-ui/frontend/src/CategoryPanel.vue
@@ -23,9 +23,24 @@ import {errorText} from './errors'
 
 type CategoryDTO = main.CategoryDTO
 
-const props = defineProps<{selectedId: number}>()
+const props = defineProps<{
+  selectedId: number
+  // the three filter dimensions the page owns; this panel only renders them and
+  // reports a pick, so the query snapshot never lives in two places.
+  parseType: string
+  fetchStatus: string
+  enabledState: string
+  // parseTypeOptions are the parse types the backend supports, in its own order.
+  // A type added there shows up here without touching this file.
+  parseTypeOptions: string[]
+}>()
 const emit = defineEmits<{
   (e: 'update:selectedId', id: number): void
+  (e: 'update:parseType', value: string): void
+  (e: 'update:fetchStatus', value: string): void
+  (e: 'update:enabledState', value: string): void
+  // clearFilters resets the category and all three dimensions at once.
+  (e: 'clearFilters'): void
   // changed fires whenever the tree or a subscription assignment moved, so the
   // subscription list next to it reloads instead of showing a stale category.
   (e: 'changed'): void
@@ -47,6 +62,47 @@ const reassignTo = ref<number | null>(null)
 const deleteBusy = ref(false)
 
 const totalSources = computed(() => categories.value.reduce((sum, c) => sum + c.sourceCount, 0))
+
+// FilterChoice is one selectable value of a dimension; an empty value is the
+// "no constraint" entry every dimension starts on.
+interface FilterChoice {
+  label: string
+  value: string
+}
+
+// the fetch health wording is the wording the subscription cards use, so a pick
+// here and a tag over there can never name the same state differently.
+const fetchStatusChoices: FilterChoice[] = [
+  {label: '全部', value: ''},
+  {label: '正常', value: 'normal'},
+  {label: '抓取失败', value: 'error'},
+  {label: '未抓取', value: 'unfetched'}
+]
+
+const enabledStateChoices: FilterChoice[] = [
+  {label: '全部', value: ''},
+  {label: '启用', value: 'enabled'},
+  {label: '停用', value: 'disabled'}
+]
+
+// a parse type is shown under the name the backend uses, which is also the name
+// printed on every card, so an unfamiliar future type still renders correctly.
+const parseTypeChoices = computed<FilterChoice[]>(() => [
+  {label: '全部', value: ''},
+  ...props.parseTypeOptions.map(value => ({label: value, value}))
+])
+
+const filterGroups = computed(() => [
+  {key: 'parseType' as const, title: '来源类型', value: props.parseType, choices: parseTypeChoices.value},
+  {key: 'fetchStatus' as const, title: '抓取状态', value: props.fetchStatus, choices: fetchStatusChoices},
+  {key: 'enabledState' as const, title: '启停状态', value: props.enabledState, choices: enabledStateChoices}
+])
+
+// the clear entry stays out of the way until something is actually filtered,
+// the category tree included: clearing returns the page to its default view.
+const hasActiveFilter = computed(
+  () => props.selectedId !== 0 || props.parseType !== '' || props.fetchStatus !== '' || props.enabledState !== ''
+)
 const editorTitle = computed(() => (form.id === 0 ? '新增分类' : `编辑分类 #${form.id}`))
 
 // the deleted category is never a valid destination for its own subscriptions.
@@ -80,6 +136,22 @@ defineExpose({reload: load})
 
 function select(id: number) {
   emit('update:selectedId', id)
+}
+
+// pick reports a single value per dimension; picking the active one again is a
+// no-op rather than a toggle, so a dimension always names exactly one state.
+function pick(key: 'parseType' | 'fetchStatus' | 'enabledState', value: string) {
+  if (props[key] === value) {
+    return
+  }
+
+  if (key === 'parseType') {
+    emit('update:parseType', value)
+  } else if (key === 'fetchStatus') {
+    emit('update:fetchStatus', value)
+  } else {
+    emit('update:enabledState', value)
+  }
 }
 
 function openCreate() {
@@ -185,7 +257,7 @@ async function confirmReassignDelete() {
       </div>
     </n-alert>
 
-    <n-spin v-else :show="loading">
+    <n-spin v-else :show="loading" class="tree-area">
       <div class="tree">
         <div class="node" :class="{active: selectedId === 0}" @click="select(0)">
           <span class="node-name">全部订阅</span>
@@ -221,6 +293,31 @@ async function confirmReassignDelete() {
         />
       </div>
     </n-spin>
+
+    <div class="filters">
+      <div class="filter-header">
+        <n-text strong>过滤</n-text>
+        <n-button v-if="hasActiveFilter" size="tiny" text type="primary" @click="emit('clearFilters')">
+          清除过滤
+        </n-button>
+      </div>
+
+      <div v-for="group in filterGroups" :key="group.key" class="filter-group">
+        <n-text depth="3" class="filter-title">{{ group.title }}</n-text>
+        <div class="filter-choices">
+          <n-tag
+            v-for="choice in group.choices"
+            :key="choice.value"
+            size="small"
+            checkable
+            :checked="group.value === choice.value"
+            @update:checked="pick(group.key, choice.value)"
+          >
+            {{ choice.label }}
+          </n-tag>
+        </div>
+      </div>
+    </div>
 
     <n-modal v-model:show="showEditor" preset="card" :title="editorTitle" style="width: 420px" :mask-closable="false">
       <n-form :model="form" label-placement="left" label-width="auto">
@@ -291,9 +388,44 @@ async function confirmReassignDelete() {
   border-bottom: 1px solid var(--n-border-color, #efeff5);
 }
 
+/* the tree takes the space the filter block below it does not need, so a long
+   category list scrolls instead of pushing the filters out of view. */
+.tree-area {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
 .tree {
   padding: 6px;
-  overflow-y: auto;
+}
+
+.filters {
+  flex: none;
+  padding: 8px 12px 12px;
+  border-top: 1px solid var(--n-border-color, #efeff5);
+}
+
+.filter-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 22px;
+}
+
+.filter-group {
+  margin-top: 8px;
+}
+
+.filter-title {
+  font-size: 12px;
+}
+
+.filter-choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
 }
 
 .node {

--- a/cmd/informer-ui/frontend/src/SourceManager.vue
+++ b/cmd/informer-ui/frontend/src/SourceManager.vue
@@ -34,6 +34,7 @@ import {
   ListSources,
   PreviewSource,
   SetSourceEnabled,
+  SupportedParseTypes,
   UpdateSource
 } from '../wailsjs/go/main/App'
 import type {main} from '../wailsjs/go/models'
@@ -70,6 +71,19 @@ const message = useMessage()
 
 const selectedCategoryId = ref(0)
 const categoryPanel = ref<InstanceType<typeof CategoryPanel> | null>(null)
+
+// the filter snapshot of this session: the sidebar picks the values, the list is
+// always the answer to the whole snapshot rather than to one dimension at a time.
+// Nothing is persisted, so reopening the page starts on "everything" again.
+const filters = reactive({parseType: '', fetchStatus: '', enabledState: ''})
+
+// the type options come from the backend, so a parse type added there needs no
+// change here to be offered and queried.
+const parseTypeFilterOptions = ref<string[]>([])
+
+// listSeq keeps the newest query the one on screen: a slower earlier request
+// that lands after a faster later one is dropped instead of overwriting it.
+let listSeq = 0
 
 const categories = ref<CategoryDTO[]>([])
 const sources = ref<SourceDTO[]>([])
@@ -117,6 +131,18 @@ const categoryOptions = computed(() => categories.value.map(c => ({label: c.name
 const selectedCategoryName = computed(
   () => categories.value.find(c => c.id === selectedCategoryId.value)?.name ?? '全部订阅'
 )
+const hasActiveFilter = computed(
+  () => filters.parseType !== '' || filters.fetchStatus !== '' || filters.enabledState !== ''
+)
+const emptyDescription = computed(() => {
+  if (hasActiveFilter.value) {
+    return '没有符合当前过滤条件的订阅'
+  }
+
+  return selectedCategoryId.value === 0
+    ? '还没有订阅，点击右上角「新增订阅」开始'
+    : '该分类下还没有订阅'
+})
 
 const parseTypeOptions = [
   {label: '自动推导（按旧规则）', value: ''},
@@ -126,8 +152,18 @@ const parseTypeOptions = [
 ]
 
 onMounted(async () => {
-  await Promise.all([loadCategories(), loadSources()])
+  await Promise.all([loadCategories(), loadParseTypeOptions(), loadSources()])
 })
+
+async function loadParseTypeOptions() {
+  try {
+    parseTypeFilterOptions.value = await SupportedParseTypes()
+  } catch (e) {
+    // the sidebar then offers the type dimension as "全部" only; every other
+    // filter keeps working, so this never blocks the page.
+    message.error(`来源类型加载失败：${errorText(e)}`)
+  }
+}
 
 async function loadCategories() {
   try {
@@ -139,20 +175,61 @@ async function loadCategories() {
 }
 
 async function loadSources() {
+  const seq = ++listSeq
+
   loading.value = true
   listError.value = ''
   try {
-    sources.value = await ListSources(selectedCategoryId.value)
+    const listed = await ListSources({
+      categoryId: selectedCategoryId.value,
+      parseType: filters.parseType,
+      fetchStatus: filters.fetchStatus,
+      enabledState: filters.enabledState
+    })
+
+    // a newer snapshot is already in flight; this answer describes a filter the
+    // sidebar no longer shows.
+    if (seq !== listSeq) {
+      return
+    }
+
+    sources.value = listed
   } catch (e) {
+    if (seq !== listSeq) {
+      return
+    }
+
+    // the previous result belongs to the previous filter, so it is dropped
+    // rather than left on screen next to the new selection.
+    sources.value = []
     listError.value = errorText(e)
   } finally {
-    loading.value = false
+    if (seq === listSeq) {
+      loading.value = false
+    }
   }
 }
 
 // onCategorySelected reloads the right hand list for the newly picked category.
 async function onCategorySelected(id: number) {
   selectedCategoryId.value = id
+  await loadSources()
+}
+
+// onFilterChanged reloads the list for one changed dimension; the other
+// dimensions and the category keep their current value.
+async function onFilterChanged(key: 'parseType' | 'fetchStatus' | 'enabledState', value: string) {
+  filters[key] = value
+  await loadSources()
+}
+
+// clearFilters returns the page to its default view: every category, every type,
+// every fetch state, enabled and disabled alike.
+async function clearFilters() {
+  selectedCategoryId.value = 0
+  filters.parseType = ''
+  filters.fetchStatus = ''
+  filters.enabledState = ''
   await loadSources()
 }
 
@@ -299,7 +376,15 @@ function openArticle(url: string) {
       <CategoryPanel
         ref="categoryPanel"
         :selected-id="selectedCategoryId"
+        :parse-type="filters.parseType"
+        :fetch-status="filters.fetchStatus"
+        :enabled-state="filters.enabledState"
+        :parse-type-options="parseTypeFilterOptions"
         @update:selected-id="onCategorySelected"
+        @update:parse-type="v => onFilterChanged('parseType', v)"
+        @update:fetch-status="v => onFilterChanged('fetchStatus', v)"
+        @update:enabled-state="v => onFilterChanged('enabledState', v)"
+        @clear-filters="clearFilters"
         @changed="onCategoryTreeChanged"
       />
     </div>
@@ -309,6 +394,9 @@ function openArticle(url: string) {
         <n-space align="center" :size="8">
           <n-text strong>{{ selectedCategoryName }}</n-text>
           <n-text depth="3" style="font-size: 12px">{{ sources.length }} 个订阅</n-text>
+          <!-- the count above is the filtered one; saying so keeps it from
+               reading as the total of the selected category. -->
+          <n-tag v-if="hasActiveFilter" size="small" type="info" :bordered="false">已过滤</n-tag>
         </n-space>
         <n-space>
           <n-button :loading="loading" size="small" tertiary @click="refreshAll">刷新</n-button>
@@ -380,9 +468,7 @@ function openArticle(url: string) {
 
           <n-empty
             v-else-if="!loading && !listError"
-            :description="selectedCategoryId === 0
-              ? '还没有订阅，点击右上角「新增订阅」开始'
-              : '该分类下还没有订阅'"
+            :description="emptyDescription"
             style="margin-top: 60px"
           />
           <div v-else style="height: 120px" />

--- a/internal/feed/model.go
+++ b/internal/feed/model.go
@@ -17,6 +17,8 @@
 
 package feed
 
+import "slices"
+
 type Config struct {
 	ID                int64 `json:"id" gorm:"primarykey;AUTO_INCREMENT"`
 	MaxInformFeedSize int   `json:"max_inform_feed_size"`
@@ -75,14 +77,20 @@ type Source struct {
 	Enabled       bool   `json:"enabled" gorm:"index"`
 }
 
+// legalParseTypes is the ordered set of supported parse types. Every legality
+// check and every list of offered types reads from here, so adding a parser
+// never leaves a caller with a stale copy of the set.
+var legalParseTypes = []string{ParseTypeFeed, ParseTypeRegex, ParseTypeJSON}
+
+// LegalParseTypes returns the supported parse types in presentation order.
+// The result is a copy: a caller can neither shrink nor reorder the set.
+func LegalParseTypes() []string {
+	return slices.Clone(legalParseTypes)
+}
+
 // IsLegalParseType reports whether the value is one of the supported parse types.
 func IsLegalParseType(parseType string) bool {
-	switch parseType {
-	case ParseTypeFeed, ParseTypeRegex, ParseTypeJSON:
-		return true
-	default:
-		return false
-	}
+	return slices.Contains(legalParseTypes, parseType)
 }
 
 // ResolveParseType returns the parser to use for the source.

--- a/internal/service/source.go
+++ b/internal/service/source.go
@@ -20,11 +20,28 @@ package service
 import (
 	"fmt"
 
-	"github.com/vogo/informer/internal/feed"
 	"gorm.io/gorm"
+
+	"github.com/vogo/informer/internal/feed"
 )
 
-// SourceQuery filters a source listing.
+// Fetch health states a source listing can be restricted to. They name the same
+// three buckets the subscription cards show, so a filter can never select a
+// state the card labels differently.
+const (
+	// FetchStatusNormal is feed.StatusNormal: the last fetch succeeded.
+	FetchStatusNormal = "normal"
+
+	// FetchStatusError is feed.StatusError: the last fetch failed.
+	FetchStatusError = "error"
+
+	// FetchStatusUnfetched is every other stored value, zero included: the
+	// source has no recorded fetch outcome yet.
+	FetchStatusUnfetched = "unfetched"
+)
+
+// SourceQuery filters a source listing. Every field is optional and the set of
+// filled ones is combined with AND; an empty query lists everything.
 type SourceQuery struct {
 	// CategoryID restricts the result to one category when it is greater than zero.
 	CategoryID int64 `json:"category_id"`
@@ -34,6 +51,18 @@ type SourceQuery struct {
 
 	// Keyword matches the title or the url when it is not empty.
 	Keyword string `json:"keyword"`
+
+	// ParseType restricts the result to one resolved parse type when it is not
+	// empty. It matches feed.Source.ResolveParseType, not the stored column, so
+	// a record that still derives its type from the historical IsJSON and Regex
+	// fields is filtered exactly as the list renders it. An unsupported value is
+	// an ErrInvalidArgument rather than a silent "everything".
+	ParseType string `json:"parse_type"`
+
+	// FetchStatus restricts the result to one of FetchStatusNormal,
+	// FetchStatusError or FetchStatusUnfetched when it is not empty. Any other
+	// value is an ErrInvalidArgument.
+	FetchStatus string `json:"fetch_status"`
 }
 
 // CreateSource stores a new source. A source is enabled by default and belongs to
@@ -147,21 +176,31 @@ func (s *Service) DeleteSource(id int64) error {
 
 // ListSources returns one page of sources ordered by id.
 func (s *Service) ListSources(query SourceQuery, page PageRequest) (*Page[*feed.Source], error) {
-	return findPage[*feed.Source](s.sourceQuery(query), "id asc", page)
+	db, err := s.sourceQuery(query)
+	if err != nil {
+		return nil, err
+	}
+
+	return findPage[*feed.Source](db, "id asc", page)
 }
 
 // AllSources returns every source ordered by id, for callers that need the whole set.
 func (s *Service) AllSources(query SourceQuery) ([]*feed.Source, error) {
+	db, err := s.sourceQuery(query)
+	if err != nil {
+		return nil, err
+	}
+
 	var sources []*feed.Source
 
-	if err := s.sourceQuery(query).Order("id asc").Find(&sources).Error; err != nil {
+	if err := db.Order("id asc").Find(&sources).Error; err != nil {
 		return nil, fmt.Errorf("list sources: %w", err)
 	}
 
 	return sources, nil
 }
 
-func (s *Service) sourceQuery(query SourceQuery) *gorm.DB {
+func (s *Service) sourceQuery(query SourceQuery) (*gorm.DB, error) {
 	db := s.db.Model(&feed.Source{})
 
 	if query.CategoryID > 0 {
@@ -177,5 +216,93 @@ func (s *Service) sourceQuery(query SourceQuery) *gorm.DB {
 		db = db.Where("title LIKE ? OR url LIKE ?", like, like)
 	}
 
-	return db
+	if query.ParseType != "" {
+		condition, err := resolvedParseTypeCondition(query.ParseType)
+		if err != nil {
+			return nil, err
+		}
+
+		db = db.Where(condition.sql, condition.args...)
+	}
+
+	if query.FetchStatus != "" {
+		condition, err := fetchStatusCondition(query.FetchStatus)
+		if err != nil {
+			return nil, err
+		}
+
+		db = db.Where(condition.sql, condition.args...)
+	}
+
+	return db, nil
+}
+
+// sourceCondition is one SQL fragment and the arguments it binds.
+type sourceCondition struct {
+	sql  string
+	args []any
+}
+
+// resolvedParseTypeCondition renders feed.Source.ResolveParseType as SQL: the
+// explicit column wins when it holds a supported value, otherwise the historical
+// derivation from IsJSON and Regex decides. Both branches are needed because a
+// record written before the parse type column existed still carries an empty -
+// or an unknown, since removed - value there.
+func resolvedParseTypeCondition(parseType string) (sourceCondition, error) {
+	if !feed.IsLegalParseType(parseType) {
+		return sourceCondition{}, fmt.Errorf("%w: unknown parse type %q", ErrInvalidArgument, parseType)
+	}
+
+	// the explicit branch alone already answers the whole question for a parse
+	// type the legacy columns cannot express - a parser added after they were
+	// frozen - because deriving would never name it either.
+	const explicit = "COALESCE(parse_type, '') = ?"
+
+	legacy := legacyParseTypeCondition(parseType)
+	if legacy.sql == "" {
+		return sourceCondition{sql: "(" + explicit + ")", args: []any{parseType}}, nil
+	}
+
+	return sourceCondition{
+		sql:  "(" + explicit + " OR (COALESCE(parse_type, '') NOT IN ? AND " + legacy.sql + "))",
+		args: append([]any{parseType, feed.LegalParseTypes()}, legacy.args...),
+	}, nil
+}
+
+// legacyParseTypeCondition mirrors feed.DeriveParseType over the historical
+// columns. It returns an empty condition for a parse type the old fields have
+// no way to express.
+func legacyParseTypeCondition(parseType string) sourceCondition {
+	switch parseType {
+	case feed.ParseTypeJSON:
+		return sourceCondition{sql: "is_json = ?", args: []any{true}}
+	case feed.ParseTypeRegex:
+		return sourceCondition{sql: "is_json = ? AND COALESCE(regex, '') != ''", args: []any{false}}
+	case feed.ParseTypeFeed:
+		return sourceCondition{sql: "is_json = ? AND COALESCE(regex, '') = ''", args: []any{false}}
+	default:
+		return sourceCondition{}
+	}
+}
+
+// fetchStatusCondition maps one health bucket to SQL. "Unfetched" is defined as
+// the complement of the two known states, so a stray value stored by an older
+// build lands in the same bucket the card shows it in instead of disappearing
+// from every filter.
+func fetchStatusCondition(status string) (sourceCondition, error) {
+	const knownStatus = "status = ?"
+
+	switch status {
+	case FetchStatusNormal:
+		return sourceCondition{sql: knownStatus, args: []any{feed.StatusNormal}}, nil
+	case FetchStatusError:
+		return sourceCondition{sql: knownStatus, args: []any{feed.StatusError}}, nil
+	case FetchStatusUnfetched:
+		return sourceCondition{
+			sql:  "COALESCE(status, 0) NOT IN ?",
+			args: []any{[]int{feed.StatusNormal, feed.StatusError}},
+		}, nil
+	default:
+		return sourceCondition{}, fmt.Errorf("%w: unknown fetch status %q", ErrInvalidArgument, status)
+	}
 }

--- a/internal/service/source.go
+++ b/internal/service/source.go
@@ -193,7 +193,8 @@ func (s *Service) AllSources(query SourceQuery) ([]*feed.Source, error) {
 
 	var sources []*feed.Source
 
-	if err := db.Order("id asc").Find(&sources).Error; err != nil {
+	err = db.Order("id asc").Find(&sources).Error
+	if err != nil {
 		return nil, fmt.Errorf("list sources: %w", err)
 	}
 

--- a/internal/service/source_filter_test.go
+++ b/internal/service/source_filter_test.go
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/feed"
+	"github.com/vogo/informer/internal/service"
+)
+
+// The titles below name the shape of each seeded record, so an expectation
+// reads as the set of cards a sidebar filter should leave visible.
+const (
+	titleExplicitFeed  = "explicit-feed"
+	titleExplicitJSON  = "explicit-json"
+	titleExplicitRegex = "explicit-regex"
+	titleLegacyFeed    = "legacy-feed"
+	titleLegacyJSON    = "legacy-json"
+	titleLegacyRegex   = "legacy-regex"
+	titleUnknownRegex  = "unknown-type-regex-fallback"
+	titleUnknownFeed   = "unknown-type-feed-fallback"
+
+	titleNormal       = "fetched-normally"
+	titleFailed       = "fetch-failed"
+	titleNeverFetched = "never-fetched"
+	titleOddStatus    = "unknown-status-value"
+
+	titleWanted   = "matches-every-dimension"
+	titleDisabled = "same-but-disabled"
+)
+
+// Columns the create API neither accepts nor validates, written directly below.
+const (
+	columnParseType = "parse_type"
+	columnStatus    = "status"
+
+	// unknownParseType is a value a build supporting another parser could have
+	// stored; this build has to fall back to the legacy fields for it.
+	unknownParseType = "rss-v9"
+)
+
+// titlesOf flattens a listing to the titles, in the order the page renders them.
+func titlesOf(sources []*feed.Source) []string {
+	titles := make([]string, 0, len(sources))
+	for _, source := range sources {
+		titles = append(titles, source.Title)
+	}
+
+	return titles
+}
+
+// storeSource creates a subscription and then writes the columns the create API
+// refuses or ignores - an unknown parse type, a fetch health state - directly,
+// which is the shape older builds left in the database. The url is derived from
+// the title because only its uniqueness matters here.
+func storeSource(t *testing.T, svc *service.Service, source *feed.Source, columns map[string]any) *feed.Source {
+	t.Helper()
+
+	if source.URL == "" {
+		source.URL = "https://example.com/" + source.Title
+	}
+
+	require.NoError(t, svc.CreateSource(source))
+
+	for column, value := range columns {
+		require.NoError(t, svc.UpdateSourceColumn(source.ID, column, value))
+	}
+
+	stored, err := svc.GetSource(source.ID)
+	require.NoError(t, err)
+
+	return stored
+}
+
+// seedParseTypeSources covers every route through ResolveParseType: an explicit
+// type, an empty type falling back to each legacy field, and an unknown type
+// that still has to fall back rather than vanish from the filters.
+func seedParseTypeSources(t *testing.T, svc *service.Service) {
+	t.Helper()
+
+	storeSource(t, svc, &feed.Source{Title: titleExplicitFeed, ParseType: feed.ParseTypeFeed}, nil)
+
+	// an explicit type wins over both legacy fields.
+	storeSource(t, svc, &feed.Source{Title: titleExplicitJSON, ParseType: feed.ParseTypeJSON, Regex: "x"}, nil)
+	storeSource(t, svc, &feed.Source{Title: titleExplicitRegex, ParseType: feed.ParseTypeRegex, IsJSON: true}, nil)
+
+	// the historical records: no parse type at all.
+	storeSource(t, svc, &feed.Source{Title: titleLegacyJSON, IsJSON: true}, nil)
+	storeSource(t, svc, &feed.Source{Title: titleLegacyRegex, Regex: "x"}, nil)
+	storeSource(t, svc, &feed.Source{Title: titleLegacyFeed}, nil)
+
+	// a parse type written by a build that supported a parser this one does not.
+	storeSource(t, svc, &feed.Source{Title: titleUnknownRegex, Regex: "x"},
+		map[string]any{columnParseType: unknownParseType})
+	storeSource(t, svc, &feed.Source{Title: titleUnknownFeed},
+		map[string]any{columnParseType: unknownParseType})
+}
+
+func TestAllSourcesFiltersByResolvedParseType(t *testing.T) {
+	svc := newService(t)
+
+	seedParseTypeSources(t, svc)
+
+	// the filter has to agree with the value the list renders per record, or the
+	// cards would show a type the sidebar did not select.
+	all, err := svc.AllSources(service.SourceQuery{})
+	require.NoError(t, err)
+	require.Len(t, all, 8)
+
+	for _, parseType := range feed.LegalParseTypes() {
+		expected := make([]string, 0, len(all))
+
+		for _, source := range all {
+			if source.ResolveParseType() == parseType {
+				expected = append(expected, source.Title)
+			}
+		}
+
+		filtered, err := svc.AllSources(service.SourceQuery{ParseType: parseType})
+		require.NoError(t, err)
+		assert.Equal(t, expected, titlesOf(filtered), "parse type %q", parseType)
+	}
+
+	// spelled out, so a regression in ResolveParseType cannot quietly move the
+	// expectation above along with the implementation.
+	jsonSources, err := svc.AllSources(service.SourceQuery{ParseType: feed.ParseTypeJSON})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleExplicitJSON, titleLegacyJSON}, titlesOf(jsonSources))
+
+	regexSources, err := svc.AllSources(service.SourceQuery{ParseType: feed.ParseTypeRegex})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleExplicitRegex, titleLegacyRegex, titleUnknownRegex}, titlesOf(regexSources))
+
+	feedSources, err := svc.AllSources(service.SourceQuery{ParseType: feed.ParseTypeFeed})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleExplicitFeed, titleLegacyFeed, titleUnknownFeed}, titlesOf(feedSources))
+}
+
+func TestListSourcesParseTypeFilterKeepsPagingSemantics(t *testing.T) {
+	svc := newService(t)
+
+	seedParseTypeSources(t, svc)
+
+	page, err := svc.ListSources(
+		service.SourceQuery{ParseType: feed.ParseTypeRegex},
+		service.PageRequest{Offset: 0, Limit: 2},
+	)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 2)
+
+	// the total counts the filtered set, not the table.
+	assert.Equal(t, int64(3), page.Total)
+	assert.True(t, page.HasMore)
+	assert.Equal(t, []string{titleExplicitRegex, titleLegacyRegex}, titlesOf(page.Items))
+	assert.Less(t, page.Items[0].ID, page.Items[1].ID, "a filtered page keeps the id ascending order")
+}
+
+func TestAllSourcesFiltersByFetchStatus(t *testing.T) {
+	svc := newService(t)
+
+	storeSource(t, svc, &feed.Source{Title: titleNormal}, map[string]any{columnStatus: feed.StatusNormal})
+	storeSource(t, svc, &feed.Source{Title: titleFailed}, map[string]any{columnStatus: feed.StatusError})
+	storeSource(t, svc, &feed.Source{Title: titleNeverFetched}, nil)
+
+	// a value no current build writes still has to land in a bucket the sidebar
+	// offers; the cards label it "未抓取" too.
+	storeSource(t, svc, &feed.Source{Title: titleOddStatus}, map[string]any{columnStatus: 7})
+
+	normal, err := svc.AllSources(service.SourceQuery{FetchStatus: service.FetchStatusNormal})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleNormal}, titlesOf(normal))
+
+	failed, err := svc.AllSources(service.SourceQuery{FetchStatus: service.FetchStatusError})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleFailed}, titlesOf(failed))
+
+	unfetched, err := svc.AllSources(service.SourceQuery{FetchStatus: service.FetchStatusUnfetched})
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleNeverFetched, titleOddStatus}, titlesOf(unfetched))
+}
+
+func TestSourceQueryRejectsUnknownFilterValues(t *testing.T) {
+	svc := newService(t)
+
+	// an unknown enum is a mistake worth reporting, never an alias of "all".
+	const (
+		absentParseType   = "agent"
+		absentFetchStatus = "half-broken"
+	)
+
+	_, err := svc.AllSources(service.SourceQuery{ParseType: absentParseType})
+	require.ErrorIs(t, err, service.ErrInvalidArgument)
+
+	_, err = svc.AllSources(service.SourceQuery{FetchStatus: absentFetchStatus})
+	require.ErrorIs(t, err, service.ErrInvalidArgument)
+
+	_, err = svc.ListSources(service.SourceQuery{ParseType: absentParseType}, service.PageRequest{})
+	require.ErrorIs(t, err, service.ErrInvalidArgument)
+
+	_, err = svc.ListSources(service.SourceQuery{FetchStatus: absentFetchStatus}, service.PageRequest{})
+	require.ErrorIs(t, err, service.ErrInvalidArgument)
+}
+
+func TestAllSourcesCombinesEveryFilterWithAnd(t *testing.T) {
+	svc := newService(t)
+
+	category := &feed.Category{Name: "过滤组合", Sort: 1}
+	require.NoError(t, svc.CreateCategory(category))
+
+	// the one record that satisfies all four dimensions: in the category, json
+	// through the legacy flag only, failed fetch, still enabled.
+	wanted := storeSource(t, svc,
+		&feed.Source{Title: titleWanted, CategoryID: category.ID, IsJSON: true},
+		map[string]any{columnStatus: feed.StatusError})
+	assert.Equal(t, feed.ParseTypeJSON, wanted.ResolveParseType())
+	assert.Empty(t, wanted.ParseType, "the record keeps deriving its type from the legacy flag")
+
+	// each of the following differs from it in exactly one dimension.
+	storeSource(t, svc, &feed.Source{Title: "other-category", IsJSON: true},
+		map[string]any{columnStatus: feed.StatusError})
+	storeSource(t, svc, &feed.Source{Title: "other-type", CategoryID: category.ID, Regex: "x"},
+		map[string]any{columnStatus: feed.StatusError})
+	storeSource(t, svc, &feed.Source{Title: "other-status", CategoryID: category.ID, IsJSON: true},
+		map[string]any{columnStatus: feed.StatusNormal})
+
+	disabled := storeSource(t, svc,
+		&feed.Source{Title: titleDisabled, CategoryID: category.ID, IsJSON: true},
+		map[string]any{columnStatus: feed.StatusError})
+	require.NoError(t, svc.SetSourceEnabled(disabled.ID, false))
+
+	enabled := true
+	combined := service.SourceQuery{
+		CategoryID:  category.ID,
+		ParseType:   feed.ParseTypeJSON,
+		FetchStatus: service.FetchStatusError,
+		Enabled:     &enabled,
+	}
+
+	matched, err := svc.AllSources(combined)
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleWanted}, titlesOf(matched))
+
+	page, err := svc.ListSources(combined, service.PageRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), page.Total)
+	assert.Equal(t, []string{titleWanted}, titlesOf(page.Items))
+
+	// dropping the enabled dimension widens the result by exactly the disabled
+	// record, which proves the dimensions are combined rather than merged.
+	combined.Enabled = nil
+
+	widened, err := svc.AllSources(combined)
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleWanted, titleDisabled}, titlesOf(widened))
+
+	// a keyword still narrows the same combination.
+	combined.Keyword = titleWanted
+
+	narrowed, err := svc.AllSources(combined)
+	require.NoError(t, err)
+	assert.Equal(t, []string{titleWanted}, titlesOf(narrowed))
+
+	// a combination nothing satisfies is an empty result, not an error.
+	combined.Keyword = ""
+	combined.FetchStatus = service.FetchStatusUnfetched
+
+	none, err := svc.AllSources(combined)
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
+func TestLegalParseTypesIsTheFilterVocabulary(t *testing.T) {
+	svc := newService(t)
+
+	types := feed.LegalParseTypes()
+	assert.Equal(t, []string{feed.ParseTypeFeed, feed.ParseTypeRegex, feed.ParseTypeJSON}, types)
+
+	// every offered type is a value the query accepts, so the sidebar can build
+	// its options from this set alone.
+	for _, parseType := range types {
+		_, err := svc.AllSources(service.SourceQuery{ParseType: parseType})
+		require.NoError(t, err, "parse type %q", parseType)
+	}
+
+	types[0] = "mutated"
+
+	assert.Equal(t, feed.ParseTypeFeed, feed.LegalParseTypes()[0], "the caller cannot mutate the shared set")
+}

--- a/internal/service/source_filter_test.go
+++ b/internal/service/source_filter_test.go
@@ -223,7 +223,7 @@ func TestSourceQueryRejectsUnknownFilterValues(t *testing.T) {
 func TestAllSourcesCombinesEveryFilterWithAnd(t *testing.T) {
 	svc := newService(t)
 
-	category := &feed.Category{Name: "过滤组合", Sort: 1}
+	category := &feed.Category{Name: "filter-combination", Sort: 1}
 	require.NoError(t, svc.CreateCategory(category))
 
 	// the one record that satisfies all four dimensions: in the category, json


### PR DESCRIPTION
## 变更

订阅页左侧栏新增三组单选过滤器，与现有分类树 AND 叠加；右侧卡片列表与工具栏计数反映过滤结果，并提供一键清除。

### 后端（过滤下沉到 SourceQuery）

- `SourceQuery` 新增 `ParseType` / `FetchStatus`，与既有 `CategoryID` / `Enabled` / `Keyword` 组合；`ListSources` 与 `AllSources` 共用同一 `sourceQuery`，分页与全量语义一致。
- 类型过滤按**解析后类型**判定，而不是只比 `parse_type` 列：合法显式值优先，否则按 `is_json` → `regex != ''` → `feed` 回退。因此选 json 能命中 `parse_type=''` 且 `IsJSON=true` 的历史数据，`parse_type` 为未知历史值时也按旧字段回退而非从所有筛选中消失。
- 抓取状态按三个互斥集合处理：`status=1` 正常、`status=2` 抓取失败、其余（0 / NULL / 旧版本写入的杂值）统一为未抓取，与卡片标签口径一致。
- 未知的类型或状态枚举返回 `ErrInvalidArgument`，不作为「全部」的别名静默放行。
- `feed.LegalParseTypes()` 成为合法类型集合的单一来源，`IsLegalParseType` 读它。

### 桌面绑定

- `ListSources` 由 `categoryID int64` 改为结构化 `*SourceQueryRequest`（四个维度；nil 表示不过滤），`ArticleLibrary.vue` 同步适配。
- 新增只读的 `SupportedParseTypes()`：不访问数据库，启动失败时类型选项仍可渲染。
- 启停维度在绑定边界用三态字符串（空 / `enabled` / `disabled`）——wails 生成的 TS 类型无法稳定表达可空布尔的「无意见」与「显式停用」之别。

### 前端

- `CategoryPanel.vue` 在分类树下方承载三组可换行的单选标签与「清除过滤」入口（清除同时把分类复位为「全部订阅」）；类型选项来自后端，未来新增类型无需改前端。
- `SourceManager.vue` 持有会话级过滤快照，每次变更提交一次完整查询；用递增序号丢弃过期响应，保证快速连续切换时展示的是最新快照；查询失败时清空列表而非用旧结果冒充。
- 工具栏在过滤生效时显示「已过滤」标记，订阅计数即过滤后结果。

## 验证

- `go test ./...`（根模块与桌面模块）全绿。新增 `internal/service/source_filter_test.go` 覆盖：解析后类型的每条路径（显式优先、空 `parse_type` 的三种回退、未知 `parse_type` 回退）、三种抓取状态（含 0 与杂值）、四维 AND 组合、过滤后的分页与 ID 升序、未知枚举报错；绑定层补充类型 / 状态 / 启停 / 组合 / 非法值用例与 `SupportedParseTypes` 在启动失败下的可用性。
- 两个模块 `golangci-lint run` 对本次改动文件均 0 issue。
- 前端 `vue-tsc --noEmit` 与 `vite build` 通过。
- **未实机运行 GUI**：桌面应用 `startup()` 会拉起调度器并可能对真实数据目录触发一次真实推送，故三组控件的交互点验留给人工验收。

## 不在范围内

订阅 CRUD 与编辑表单、分类管理、新增来源类型、服务端分页、关键词搜索 UI（`SourceQuery.Keyword` 已存在但本次不接 UI）；过滤态仅会话级，不持久化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)