### PR TITLE
feat(feed): 新增 agent 类型订阅源，通过 Claude Code 命令行抓取

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 每天把「日期信息 + 每日鸡汤 + 订阅文章推荐」汇总成一条消息，写入本地 Markdown 日报，并推送到钉钉或飞书机器人。
 
-订阅源支持三种解析方式：标准 feed（RSS/Atom）、正则匹配网页、JSON 接口。
+订阅源支持四种解析方式：标准 feed（RSS/Atom）、正则匹配网页、JSON 接口，以及交给命令行 AI Agent 去找。
 
 ## 一、选择使用方式
 
@@ -126,7 +126,9 @@ informer 不会自动同步多个数据主目录，也不支持同时使用多�
 
 前三项为 0 会让推荐算法选不出任何文章，因此被拒绝；超出合理范围的值同样会被拒绝，且被拒绝的保存不会改动文件。
 
-除 `feed` 节外还有一个顶层节 `schedule`，只被桌面版「定时任务」读取，命令行与系统 crontab 会忽略它（命令行的定时推送仍由 crontab 负责）：
+除 `feed` 节外还有一个顶层节 `agent`，供 `agent` 类型的订阅使用，详见[「agent 解析订阅」](#agent-解析订阅)。
+
+还有一个顶层节 `schedule`，只被桌面版「定时任务」读取，命令行与系统 crontab 会忽略它（命令行的定时推送仍由 crontab 负责）：
 
 | 配置项 | 含义 | 取值 |
 | --- | --- | --- |
@@ -137,7 +139,7 @@ informer 不会自动同步多个数据主目录，也不支持同时使用多�
 
 无论是命令行手写还是桌面版「设置」页保存，写入都遵守下面几条约定：
 
-- **保留未知字段**：保存只替换 `feed` 与 `schedule` 两节，文件里其它顶层字段（包括这个版本还不认识的字段）连同顺序一起原样保留。
+- **保留未知字段**：保存只替换 `feed`、`agent` 与 `schedule` 三节，文件里其它顶层字段（包括这个版本还不认识的字段）连同顺序一起原样保留。
 - **原子替换**：先写同目录下的临时文件再 `rename` 覆盖，所以并发运行的 crontab 读到的要么是旧文件、要么是新文件，不会读到写了一半的内容。
 - **跨进程写锁**：写入前会创建 `informer.json.lock`，两个「读—改—写」不会互相覆盖造成丢失更新。锁有等待上限，
   等不到会直接报错而不是一直卡住；进程被杀留下的陈旧锁会在明显过期后被自动接管。
@@ -148,7 +150,8 @@ informer 不会自动同步多个数据主目录，也不支持同时使用多�
 
 ```json
 {
-  "webhook": "https://oapi.dingtalk.com/robot/send?access_token=xxxxx"
+  "webhook": "https://oapi.dingtalk.com/robot/send?access_token=xxxxx",
+  "agent_api_key": "sk-xxxxx"
 }
 ```
 
@@ -156,6 +159,7 @@ informer 不会自动同步多个数据主目录，也不支持同时使用多�
   （Windows 不支持 Unix 权限位，这一步在 Windows 上无法校验）。
 - 桌面版「设置」页只显示「是否已配置」和一段打码后的前缀，完整地址不会回传到界面。
 - 命令行显式传入的地址**优先**；不传地址时才使用这个文件里保存的 webhook。
+- `agent_api_key` 是 `agent` 类型订阅调用 AI Agent 时使用的密钥，同样只存在这个文件里；桌面版只显示「是否已配置」，不回传原文。
 
 ## 五、订阅管理命令
 
@@ -163,6 +167,7 @@ informer 不会自动同步多个数据主目录，也不支持同时使用多�
 ./informer feed list              # 列出所有订阅（id, 标题, 地址）
 ./informer feed view <id>         # 查看单个订阅的全部字段
 ./informer feed add <标题> <地址>   # 添加订阅
+./informer feed agent <标题> <提示词>  # 添加 agent 类型订阅（不需要地址）
 ./informer feed copy <id>         # 复制一个订阅（连同其设置）
 ./informer feed remove <id>       # 删除订阅
 ./informer feed update <id> <字段> <值>   # 修改订阅的某个字段
@@ -177,11 +182,12 @@ informer 不会自动同步多个数据主目录，也不支持同时使用多�
 | `title` / `url` | 订阅标题与抓取地址 |
 | `weight` | 文章排序权重，越大越靠前 |
 | `max_fetch_num` | 该订阅单次抓取的文章数上限 |
-| `parse_type` | 解析方式，合法值 `feed` / `regex` / `json` |
+| `parse_type` | 解析方式，合法值 `feed` / `regex` / `json` / `agent` |
 | `category_id` | 所属分类，默认 `1`（内置「未分类」，不可删除） |
 | `enabled` | 是否参与定时抓取；停用后 `feed parse` 仍可测试 |
 | `regex` / `title_exp` / `url_exp` | 正则解析用的匹配式与标题、链接表达式 |
 | `json_title_path` / `json_url_path` | JSON 解析用的标题、链接路径 |
+| `agent_prompt` / `agent_provider` | agent 解析用的提示词与指定的 Agent |
 | `redirect` | 是否跟随解析出的链接跳转 |
 
 示例：
@@ -211,6 +217,59 @@ informer 不会自动同步多个数据主目录，也不支持同时使用多�
 ```
 
 `title_exp` 和 `url_exp` 用 `$1`、`$2` 引用 `regex` 中的捕获分组，可与固定前缀拼接成完整链接。
+
+### agent 解析订阅
+
+`agent` 类型的订阅不抓取某个固定地址，而是把一段自然语言的任务交给本机安装的命令行 AI Agent 去找文章。
+**你只需要描述要找什么**，JSON 输出格式要求由 informer 自动追加到提示词末尾，返回内容再被解析成文章列表：
+
+```bash
+./informer feed agent "Go 语言周报" "搜索 Go 语言最近的技术文章与发布公告，挑出最值得阅读的几篇，给出标题和链接。"
+# 1,	Go 语言周报,	agent
+
+./informer feed update 1 max_fetch_num 3   # 最多要 3 条，这个数字也会写进提示词
+
+# 测试抓取（真的会调用一次 Agent，可能需要几十秒）
+./informer feed parse 1
+```
+
+几点约定：
+
+- 订阅本身**不需要 `url`**；`agent_prompt` 为空的 agent 订阅会被拒绝保存。
+- 返回条目里 `title` 为空、或 `url` 不是 `http://` / `https://` 开头的会被丢弃，重复链接只保留一条，
+  所以 Agent 给出相对路径或编造格式时不会污染文章库。
+- Agent 只被允许使用只读的联网工具（默认 `WebSearch,WebFetch`），并且整次运行有超时上限，
+  超时会被杀掉并把原因记到订阅的抓取状态里，不会拖住整轮抓取。
+
+Agent 的接口地址、密钥与模型是全局配置，写在 `informer.json` 的 `agent` 节（密钥除外）：
+
+```json
+{
+  "agent": {
+    "provider": "claude",
+    "base_url": "",
+    "model": "",
+    "allowed_tools": "WebSearch,WebFetch",
+    "timeout_seconds": 300,
+    "command": ""
+  }
+}
+```
+
+| 配置项 | 含义 | 取值 |
+| --- | --- | --- |
+| `provider` | 使用哪个命令行 Agent | 目前只实现了 `claude`（Claude Code）；`codex` 已预留但本版本运行时会报错 |
+| `base_url` | Agent 的接口地址 | 留空表示沿用本机上该 Agent 自己的配置 |
+| `model` | 使用的模型 | 留空表示沿用 Agent 的默认模型 |
+| `allowed_tools` | 允许 Agent 使用的工具，逗号分隔 | 留空使用默认 `WebSearch,WebFetch` |
+| `timeout_seconds` | 单次运行超时 | 填 0 表示使用默认 300 秒，合法范围 10 ~ 3600 |
+| `command` | Agent 可执行文件 | 留空表示用 `PATH` 里的 `claude` |
+
+API Key 不写进 `informer.json`，而是放在同目录的 `informer.secret.json` 的 `agent_api_key` 字段里。
+`base_url` 与 `agent_api_key` 都留空时，informer 直接运行 `claude`，用的就是本机 `claude` 自身已登录的凭据——
+也就是说，只要本机 `claude` 能跑，agent 订阅就能跑，不需要额外配置。
+
+前置条件：本机已安装 Claude Code 命令行（`claude --version` 能正常输出）。
 
 ## 六、桌面版 informer-ui
 

--- a/cmd/informer-ui/binding.go
+++ b/cmd/informer-ui/binding.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/vogo/informer/internal/agent"
 	"github.com/vogo/informer/internal/feed"
 	"github.com/vogo/informer/internal/service"
 )
@@ -53,6 +54,8 @@ type SourceDTO struct {
 	JSONTitlePath     string `json:"jsonTitlePath"`
 	JSONURLPath       string `json:"jsonURLPath"`
 	ParseType         string `json:"parseType"`
+	AgentProvider     string `json:"agentProvider"`
+	AgentPrompt       string `json:"agentPrompt"`
 	CategoryID        int64  `json:"categoryId"`
 	Enabled           bool   `json:"enabled"`
 	Status            int    `json:"status"`
@@ -78,6 +81,8 @@ type SaveSourceRequest struct {
 	JSONTitlePath string `json:"jsonTitlePath"`
 	JSONURLPath   string `json:"jsonURLPath"`
 	ParseType     string `json:"parseType"`
+	AgentProvider string `json:"agentProvider"`
+	AgentPrompt   string `json:"agentPrompt"`
 	CategoryID    int64  `json:"categoryId"`
 	Enabled       bool   `json:"enabled"`
 }
@@ -106,6 +111,8 @@ func toSourceDTO(source *feed.Source) *SourceDTO {
 		JSONTitlePath:     source.JsonTitlePath,
 		JSONURLPath:       source.JsonURLPath,
 		ParseType:         source.ParseType,
+		AgentProvider:     source.AgentProvider,
+		AgentPrompt:       source.AgentPrompt,
 		CategoryID:        source.CategoryID,
 		Enabled:           source.Enabled,
 		Status:            source.Status,
@@ -147,6 +154,14 @@ type SourceQueryRequest struct {
 // database and therefore stays available while the app reports a startup error.
 func (a *App) SupportedParseTypes() []string {
 	return feed.LegalParseTypes()
+}
+
+// SupportedAgentProviders returns the agent providers a subscription of the agent
+// parse type can be pinned to, in presentation order. Like SupportedParseTypes it
+// answers from the domain set itself and reads no database, so the subscription
+// form can offer exactly the values the service accepts.
+func (a *App) SupportedAgentProviders() []string {
+	return agent.LegalProviders()
 }
 
 // ListSources returns the subscriptions matching the filter snapshot, ordered by
@@ -320,6 +335,8 @@ func applyRequest(source *feed.Source, req *SaveSourceRequest) *feed.Source {
 	source.JsonTitlePath = req.JSONTitlePath
 	source.JsonURLPath = req.JSONURLPath
 	source.ParseType = req.ParseType
+	source.AgentProvider = req.AgentProvider
+	source.AgentPrompt = req.AgentPrompt
 	source.CategoryID = req.CategoryID
 	source.Enabled = req.Enabled
 

--- a/cmd/informer-ui/binding_manage_test.go
+++ b/cmd/informer-ui/binding_manage_test.go
@@ -164,8 +164,9 @@ func titlesOf(sources []*SourceDTO) []string {
 
 // The filter vocabulary and the seeded titles the listing cases share.
 const (
-	parseTypeFeed = "feed"
-	parseTypeJSON = "json"
+	parseTypeFeed  = "feed"
+	parseTypeJSON  = "json"
+	parseTypeAgent = "agent"
 
 	fetchStatusUnfetched = "unfetched"
 
@@ -222,7 +223,7 @@ func TestSupportedParseTypesFeedsTheFilter(t *testing.T) {
 	app := newTestApp(t)
 
 	types := app.SupportedParseTypes()
-	assert.Equal(t, []string{parseTypeFeed, "regex", parseTypeJSON}, types)
+	assert.Equal(t, []string{parseTypeFeed, "regex", parseTypeJSON, parseTypeAgent}, types)
 
 	// the sidebar builds its options from this list alone, so every entry has to
 	// be a value the listing accepts.
@@ -294,7 +295,7 @@ func TestListSourcesRejectsUnknownFilterValues(t *testing.T) {
 
 	// an unknown enum is reported, so a stale frontend can never be shown an
 	// unfiltered list while its sidebar claims a filter is active.
-	_, err := app.ListSources(&SourceQueryRequest{ParseType: "agent"})
+	_, err := app.ListSources(&SourceQueryRequest{ParseType: "rss-v9"})
 	require.ErrorIs(t, err, service.ErrInvalidArgument)
 
 	_, err = app.ListSources(&SourceQueryRequest{FetchStatus: "broken"})

--- a/cmd/informer-ui/binding_settings.go
+++ b/cmd/informer-ui/binding_settings.go
@@ -20,6 +20,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/vogo/informer/internal/agent"
 	"github.com/vogo/informer/internal/feed"
 	"github.com/vogo/informer/internal/service"
 )
@@ -30,6 +31,18 @@ type FeedConfigDTO struct {
 	FeedExpireDays    int `json:"feedExpireDays"`
 	SameSiteMaxCount  int `json:"sameSiteMaxCount"`
 	MaxFetchNum       int `json:"maxFetchNum"`
+}
+
+// AgentConfigDTO is the editable agent section of informer.json. It carries no
+// api key: the credential lives in the separate 0600 file and is saved through
+// SaveAgentAPIKey, so the settings page never has to hold it to save the rest.
+type AgentConfigDTO struct {
+	Provider       string `json:"provider"`
+	BaseURL        string `json:"baseURL"`
+	Model          string `json:"model"`
+	AllowedTools   string `json:"allowedTools"`
+	TimeoutSeconds int    `json:"timeoutSeconds"`
+	Command        string `json:"command"`
 }
 
 // ScheduleDTO is the editable schedule section of informer.json.
@@ -59,6 +72,15 @@ type ConfigViewDTO struct {
 	// ScheduleDefaults are the documented starting values of the schedule section.
 	ScheduleDefaults *ScheduleDTO `json:"scheduleDefaults"`
 
+	// Agent is the stored section, or the defaults when the file has none.
+	Agent *AgentConfigDTO `json:"agent"`
+
+	// AgentDefaults are the starting values of the agent section.
+	AgentDefaults *AgentConfigDTO `json:"agentDefaults"`
+
+	// AgentProviders are the providers the agent section accepts, in order.
+	AgentProviders []string `json:"agentProviders"`
+
 	// PreservedKeys are the top level fields this build does not edit and keeps
 	// on every save, listed so the page can state that nothing is dropped.
 	PreservedKeys []string `json:"preservedKeys"`
@@ -71,6 +93,11 @@ type SecretsViewDTO struct {
 	Exists            bool   `json:"exists"`
 	WebhookConfigured bool   `json:"webhookConfigured"`
 	Webhook           string `json:"webhook"`
+
+	// AgentAPIKeyConfigured reports whether an agent api key is stored. The key
+	// itself is never sent to the page: unlike the webhook it is a real
+	// credential, and the page only needs to know that one exists.
+	AgentAPIKeyConfigured bool `json:"agentApiKeyConfigured"`
 }
 
 // HistoryIndexDTO reports what one history index rebuild did.
@@ -106,6 +133,7 @@ func (a *App) ReadConfig() (*ConfigViewDTO, error) {
 
 	defaults := toFeedConfigDTO(service.DefaultFeedConfig())
 	scheduleDefaults := toScheduleDTO(service.DefaultScheduleConfig())
+	agentDefaults := toAgentConfigDTO(service.DefaultAgentConfig())
 
 	dto := &ConfigViewDTO{
 		Path:             view.Path,
@@ -114,6 +142,9 @@ func (a *App) ReadConfig() (*ConfigViewDTO, error) {
 		Schedule:         scheduleDefaults,
 		Defaults:         defaults,
 		ScheduleDefaults: scheduleDefaults,
+		Agent:            agentDefaults,
+		AgentDefaults:    agentDefaults,
+		AgentProviders:   agent.LegalProviders(),
 		PreservedKeys:    view.PreservedKeys,
 	}
 
@@ -123,6 +154,10 @@ func (a *App) ReadConfig() (*ConfigViewDTO, error) {
 
 	if view.Schedule != nil {
 		dto.Schedule = toScheduleDTO(view.Schedule)
+	}
+
+	if view.Agent != nil {
+		dto.Agent = toAgentConfigDTO(view.Agent)
 	}
 
 	if dto.PreservedKeys == nil {
@@ -167,10 +202,11 @@ func (a *App) ReadSecrets() (*SecretsViewDTO, error) {
 	}
 
 	return &SecretsViewDTO{
-		Path:              view.Path,
-		Exists:            view.Exists,
-		WebhookConfigured: view.WebhookConfigured,
-		Webhook:           view.Webhook,
+		Path:                  view.Path,
+		Exists:                view.Exists,
+		WebhookConfigured:     view.WebhookConfigured,
+		Webhook:               view.Webhook,
+		AgentAPIKeyConfigured: view.AgentAPIKeyConfigured,
 	}, nil
 }
 
@@ -234,6 +270,52 @@ func (a *App) SaveSchedule(req *ScheduleDTO) error {
 		Enabled: req.Enabled,
 		Time:    req.Time,
 	})
+}
+
+// SaveAgentConfig validates and stores the agent section of informer.json.
+// Like every other section save it re-reads the whole document under a write lock,
+// so a field this build does not edit survives.
+func (a *App) SaveAgentConfig(req *AgentConfigDTO) error {
+	if req == nil {
+		return fmt.Errorf("%w: request is nil", service.ErrInvalidArgument)
+	}
+
+	err := a.ready()
+	if err != nil {
+		return err
+	}
+
+	return a.svc.SaveAgentConfig(&agent.Config{
+		Provider:       req.Provider,
+		BaseURL:        req.BaseURL,
+		Model:          req.Model,
+		AllowedTools:   req.AllowedTools,
+		TimeoutSeconds: req.TimeoutSeconds,
+		Command:        req.Command,
+	})
+}
+
+// SaveAgentAPIKey stores the agent api key in the separate 0600 credential file.
+// An empty value clears it, which puts the agent back on whatever credentials its
+// own command line is logged in with.
+func (a *App) SaveAgentAPIKey(apiKey string) error {
+	err := a.ready()
+	if err != nil {
+		return err
+	}
+
+	return a.svc.SaveAgentAPIKey(apiKey)
+}
+
+func toAgentConfigDTO(config *agent.Config) *AgentConfigDTO {
+	return &AgentConfigDTO{
+		Provider:       config.Provider,
+		BaseURL:        config.BaseURL,
+		Model:          config.Model,
+		AllowedTools:   config.AllowedTools,
+		TimeoutSeconds: config.TimeoutSeconds,
+		Command:        config.Command,
+	}
 }
 
 func toFeedConfigDTO(config *feed.Config) *FeedConfigDTO {

--- a/cmd/informer-ui/frontend/src/SettingsPanel.vue
+++ b/cmd/informer-ui/frontend/src/SettingsPanel.vue
@@ -13,6 +13,7 @@ import {
   NInputNumber,
   NPopconfirm,
   NSpace,
+  NSelect,
   NSpin,
   NSwitch,
   NTag,
@@ -20,7 +21,17 @@ import {
   NTimePicker,
   useMessage
 } from 'naive-ui'
-import {ReadConfig, ReadSecrets, RebuildHistoryIndex, SaveConfig, SaveSchedule, SaveWebhook, TriggerNow} from '../wailsjs/go/main/App'
+import {
+  ReadConfig,
+  ReadSecrets,
+  RebuildHistoryIndex,
+  SaveAgentAPIKey,
+  SaveAgentConfig,
+  SaveConfig,
+  SaveSchedule,
+  SaveWebhook,
+  TriggerNow
+} from '../wailsjs/go/main/App'
 import type {main} from '../wailsjs/go/models'
 import {errorText} from './errors'
 
@@ -43,6 +54,23 @@ const form = reactive({
   sameSiteMaxCount: 3,
   maxFetchNum: 1
 })
+
+// the agent section drives every「agent」订阅: the endpoint, the model and the
+// tool set. The api key is not part of it - it is saved on its own below, so this
+// form never has to hold a credential it was never shown.
+const agent = reactive({
+  provider: '',
+  baseURL: '',
+  model: '',
+  allowedTools: '',
+  timeoutSeconds: 0,
+  command: ''
+})
+const agentProviderOptions = ref<{label: string; value: string}[]>([])
+const agentSaving = ref(false)
+const agentAPIKeyConfigured = ref(false)
+const agentAPIKeyInput = ref('')
+const agentAPIKeySaving = ref(false)
 
 const secretsPath = ref('')
 const webhookConfigured = ref(false)
@@ -77,10 +105,13 @@ async function load() {
     preservedKeys.value = config.preservedKeys
     Object.assign(form, config.feed)
     Object.assign(schedule, config.schedule)
+    Object.assign(agent, config.agent)
+    agentProviderOptions.value = config.agentProviders.map(value => ({label: value, value}))
 
     secretsPath.value = secrets.path
     webhookConfigured.value = secrets.webhookConfigured
     webhook.value = secrets.webhook
+    agentAPIKeyConfigured.value = secrets.agentApiKeyConfigured
   } catch (e) {
     loadError.value = errorText(e)
   } finally {
@@ -132,6 +163,40 @@ async function triggerNow() {
     triggerError.value = errorText(e)
   } finally {
     triggering.value = false
+  }
+}
+
+async function saveAgent() {
+  agentSaving.value = true
+  try {
+    await SaveAgentConfig({
+      provider: agent.provider,
+      baseURL: agent.baseURL,
+      model: agent.model,
+      allowedTools: agent.allowedTools,
+      timeoutSeconds: agent.timeoutSeconds,
+      command: agent.command
+    })
+    message.success('Agent 配置已保存，下一次抓取即生效')
+    await load()
+  } catch (e) {
+    message.error(`保存失败：${errorText(e)}`)
+  } finally {
+    agentSaving.value = false
+  }
+}
+
+async function saveAgentAPIKey() {
+  agentAPIKeySaving.value = true
+  try {
+    await SaveAgentAPIKey(agentAPIKeyInput.value)
+    message.success(agentAPIKeyInput.value.trim() === '' ? '已清除 API Key' : 'API Key 已保存')
+    agentAPIKeyInput.value = ''
+    await load()
+  } catch (e) {
+    message.error(`保存失败：${errorText(e)}`)
+  } finally {
+    agentAPIKeySaving.value = false
   }
 }
 
@@ -207,6 +272,63 @@ async function rebuild() {
           <n-space justify="end">
             <n-button :disabled="loading" @click="load">重新读取</n-button>
             <n-button :loading="saving" type="primary" @click="save">保存配置</n-button>
+          </n-space>
+        </template>
+      </n-card>
+
+      <n-card size="small" title="Agent 配置" style="margin-bottom: 16px">
+        <n-text depth="3" style="font-size: 12px">
+          「agent」类型的订阅会调用命令行 Agent 抓取；这里留空的项使用本机上该 Agent 自身的登录与默认设置。
+        </n-text>
+
+        <n-form label-placement="left" label-width="auto" style="margin-top: 12px">
+          <n-form-item label="Agent 类型">
+            <n-select v-model:value="agent.provider" :options="agentProviderOptions" />
+          </n-form-item>
+          <n-form-item label="接口地址">
+            <n-input v-model:value="agent.baseURL" placeholder="留空使用默认；例如 https://api.anthropic.com" />
+          </n-form-item>
+          <n-form-item label="模型">
+            <n-input v-model:value="agent.model" placeholder="留空使用 Agent 默认模型；例如 claude-sonnet-5" />
+          </n-form-item>
+          <n-form-item label="可用工具">
+            <n-input v-model:value="agent.allowedTools" placeholder="逗号分隔，例如 WebSearch,WebFetch" />
+          </n-form-item>
+          <n-form-item label="超时（秒）">
+            <n-input-number v-model:value="agent.timeoutSeconds" :min="0" :max="3600" style="width: 100%" />
+          </n-form-item>
+          <n-form-item label="可执行文件">
+            <n-input v-model:value="agent.command" placeholder="留空使用 PATH 中的 claude" />
+          </n-form-item>
+        </n-form>
+        <n-text depth="3" style="font-size: 12px">「超时」填 0 表示使用默认窗口（300 秒）。</n-text>
+
+        <n-descriptions :column="1" size="small" style="margin: 12px 0">
+          <n-descriptions-item label="API Key">
+            <n-space :size="8" align="center">
+              <n-tag v-if="agentAPIKeyConfigured" size="small" type="success">已配置</n-tag>
+              <n-tag v-else size="small" :bordered="false">未配置（使用本机登录）</n-tag>
+            </n-space>
+          </n-descriptions-item>
+        </n-descriptions>
+
+        <n-space :size="8">
+          <n-input
+            v-model:value="agentAPIKeyInput"
+            type="password"
+            show-password-on="click"
+            placeholder="粘贴 API Key；留空保存表示清除"
+            style="flex: 1"
+          />
+          <n-button :loading="agentAPIKeySaving" @click="saveAgentAPIKey">保存 Key</n-button>
+        </n-space>
+        <n-text depth="3" style="display: block; margin-top: 8px; font-size: 12px">
+          API Key 与机器人地址存放在同一个 0600 文件中，不会写入 informer.json。
+        </n-text>
+
+        <template #footer>
+          <n-space justify="end">
+            <n-button :loading="agentSaving" type="primary" @click="saveAgent">保存 Agent 配置</n-button>
           </n-space>
         </template>
       </n-card>

--- a/cmd/informer-ui/frontend/src/SourceManager.vue
+++ b/cmd/informer-ui/frontend/src/SourceManager.vue
@@ -34,6 +34,7 @@ import {
   ListSources,
   PreviewSource,
   SetSourceEnabled,
+  SupportedAgentProviders,
   SupportedParseTypes,
   UpdateSource
 } from '../wailsjs/go/main/App'
@@ -63,6 +64,8 @@ interface SourceForm {
   jsonTitlePath: string
   jsonURLPath: string
   parseType: string
+  agentProvider: string
+  agentPrompt: string
   categoryId: number
   enabled: boolean
 }
@@ -119,12 +122,15 @@ function emptyForm(): SourceForm {
     jsonTitlePath: '',
     jsonURLPath: '',
     parseType: '',
+    agentProvider: '',
+    agentPrompt: '',
     categoryId: 0,
     enabled: true
   }
 }
 
 const modalTitle = computed(() => (form.id === 0 ? '新增订阅' : `编辑订阅 #${form.id}`))
+const isAgentType = computed(() => form.parseType === 'agent')
 const showRegexFields = computed(() => form.parseType === 'regex' || form.parseType === '')
 const showJsonFields = computed(() => form.parseType === 'json' || form.parseType === '')
 const categoryOptions = computed(() => categories.value.map(c => ({label: c.name, value: c.id})))
@@ -148,12 +154,33 @@ const parseTypeOptions = [
   {label: '自动推导（按旧规则）', value: ''},
   {label: 'feed（RSS / Atom）', value: 'feed'},
   {label: 'regex（正则匹配）', value: 'regex'},
-  {label: 'json（路径提取）', value: 'json'}
+  {label: 'json（路径提取）', value: 'json'},
+  {label: 'agent（AI 代理抓取）', value: 'agent'}
 ]
 
+// the provider list comes from the backend, so an agent added there needs no
+// change here to be offered.
+const agentProviderOptions = ref<{label: string; value: string}[]>([
+  {label: '使用全局配置', value: ''}
+])
+
 onMounted(async () => {
-  await Promise.all([loadCategories(), loadParseTypeOptions(), loadSources()])
+  await Promise.all([loadCategories(), loadParseTypeOptions(), loadAgentProviders(), loadSources()])
 })
+
+async function loadAgentProviders() {
+  try {
+    const providers = await SupportedAgentProviders()
+    agentProviderOptions.value = [
+      {label: '使用全局配置', value: ''},
+      ...providers.map(value => ({label: value, value}))
+    ]
+  } catch (e) {
+    // the form then only offers「使用全局配置」, which is the working default;
+    // everything else on the page keeps functioning.
+    message.error(`Agent 类型加载失败：${errorText(e)}`)
+  }
+}
 
 async function loadParseTypeOptions() {
   try {
@@ -264,6 +291,8 @@ function openEdit(row: SourceDTO) {
     jsonTitlePath: row.jsonTitlePath,
     jsonURLPath: row.jsonURLPath,
     parseType: row.parseType,
+    agentProvider: row.agentProvider,
+    agentPrompt: row.agentPrompt,
     categoryId: row.categoryId,
     enabled: row.enabled
   })
@@ -271,7 +300,14 @@ function openEdit(row: SourceDTO) {
 }
 
 async function save() {
-  if (!form.url.trim()) {
+  // an agent source is driven by its prompt and has no address at all, so the
+  // two types cannot share one required field.
+  if (isAgentType.value) {
+    if (!form.agentPrompt.trim()) {
+      message.warning('请填写 Agent 提示词')
+      return
+    }
+  } else if (!form.url.trim()) {
     message.warning('请填写订阅 URL')
     return
   }
@@ -296,6 +332,8 @@ async function save() {
       jsonTitlePath: form.jsonTitlePath,
       jsonURLPath: form.jsonURLPath,
       parseType: form.parseType,
+      agentProvider: form.agentProvider,
+      agentPrompt: form.agentPrompt,
       categoryId: form.categoryId,
       enabled: form.enabled
     }
@@ -487,7 +525,7 @@ function openArticle(url: string) {
         <n-form-item label="标题">
           <n-input v-model:value="form.title" placeholder="订阅名称，例如：阮一峰 blog" />
         </n-form-item>
-        <n-form-item label="URL" required>
+        <n-form-item v-if="!isAgentType" label="URL" required>
           <n-input v-model:value="form.url" placeholder="https://example.com/atom.xml" />
         </n-form-item>
         <n-form-item label="分类">
@@ -498,7 +536,7 @@ function openArticle(url: string) {
             clearable
           />
         </n-form-item>
-        <n-form-item label="自定义请求">
+        <n-form-item v-if="!isAgentType" label="自定义请求">
           <n-input
             v-model:value="form.curl"
             type="textarea"
@@ -510,7 +548,25 @@ function openArticle(url: string) {
           <n-select v-model:value="form.parseType" :options="parseTypeOptions" />
         </n-form-item>
 
-        <template v-if="showRegexFields">
+        <template v-if="isAgentType">
+          <n-divider title-placement="left" style="margin: 8px 0">Agent 解析参数</n-divider>
+          <n-form-item label="Agent">
+            <n-select v-model:value="form.agentProvider" :options="agentProviderOptions" />
+          </n-form-item>
+          <n-form-item label="提示词" required>
+            <n-input
+              v-model:value="form.agentPrompt"
+              type="textarea"
+              placeholder="用自然语言描述要找什么，例如：搜索今天 Go 语言相关的技术文章，给出标题和链接"
+              :autosize="{minRows: 4, maxRows: 10}"
+            />
+          </n-form-item>
+          <n-text depth="3" style="display: block; margin: -4px 0 12px 0; font-size: 12px">
+            只需要描述任务本身，JSON 输出格式要求由 informer 自动追加；接口地址、密钥与模型在「设置」中配置。
+          </n-text>
+        </template>
+
+        <template v-if="!isAgentType && showRegexFields">
           <n-divider title-placement="left" style="margin: 8px 0">正则解析参数</n-divider>
           <n-form-item label="正则表达式">
             <n-input v-model:value="form.regex" placeholder='例如：,"url":"([^"]+)","title":"([^"]+)",' />
@@ -523,7 +579,7 @@ function openArticle(url: string) {
           </n-form-item>
         </template>
 
-        <template v-if="showJsonFields">
+        <template v-if="!isAgentType && showJsonFields">
           <n-divider title-placement="left" style="margin: 8px 0">JSON 解析参数</n-divider>
           <n-form-item label="标题路径">
             <n-input v-model:value="form.jsonTitlePath" placeholder="例如：data/items[]/title" />

--- a/examples/informer.json
+++ b/examples/informer.json
@@ -5,6 +5,14 @@
     "max_inform_feed_size": 20,
     "max_fetch_num": 1
   },
+  "agent": {
+    "provider": "claude",
+    "base_url": "",
+    "model": "",
+    "allowed_tools": "WebSearch,WebFetch",
+    "timeout_seconds": 300,
+    "command": ""
+  },
   "schedule": {
     "enabled": false,
     "time": "10:00"

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package agent turns a plain language instruction into a list of articles by
+// driving a coding agent command line.
+//
+// The caller only supplies the instruction: this package appends the machine
+// readable output contract, runs the agent, and parses what came back. That split
+// is the whole point - a source author writes what they want in their own words
+// and never has to know the json shape informer expects.
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Supported agent providers.
+const (
+	// ProviderClaude drives the "claude" command line of Claude Code.
+	ProviderClaude = "claude"
+
+	// ProviderCodex names the codex command line. It is accepted by the
+	// configuration and refused at run time until a runner exists, so a source
+	// can already record the intent without silently running the wrong agent.
+	ProviderCodex = "codex"
+)
+
+// Errors returned by this package.
+var (
+	// ErrUnsupportedProvider marks a provider this build cannot run.
+	ErrUnsupportedProvider = errors.New("unsupported agent provider")
+
+	// ErrEmptyPrompt marks a run without any instruction to give the agent.
+	ErrEmptyPrompt = errors.New("agent prompt is empty")
+
+	// ErrNoJSONOutput marks output that carries no json document at all.
+	ErrNoJSONOutput = errors.New("agent output carries no json result")
+
+	// ErrAgentFailed marks a run the agent itself reported as failed.
+	ErrAgentFailed = errors.New("agent run failed")
+)
+
+// Defaults and bounds of one agent run.
+const (
+	// DefaultProvider is the agent used when a configuration names none.
+	DefaultProvider = ProviderClaude
+
+	// DefaultTimeoutSeconds bounds one agent run. An agent that browses the web
+	// is far slower than an http fetch, so the window is minutes, not seconds.
+	DefaultTimeoutSeconds = 300
+
+	// MinTimeoutSeconds and MaxTimeoutSeconds bound the configured timeout.
+	MinTimeoutSeconds = 10
+	MaxTimeoutSeconds = 3600
+
+	// DefaultAllowedTools is the tool set an agent source may use. Reading the
+	// public web is what a subscription needs; nothing here can write.
+	DefaultAllowedTools = "WebSearch,WebFetch"
+
+	// DefaultMaxItems bounds how many articles one run is asked for when the
+	// source sets no fetch limit of its own.
+	DefaultMaxItems = 20
+
+	// MaxItemsCap is the highest item count a prompt ever asks for.
+	MaxItemsCap = 100
+)
+
+// Config is everything one agent run needs beyond the instruction itself.
+//
+// The json tags describe the "agent" section of informer.json. APIKey carries no
+// tag on purpose: a credential belongs in the separate secret file, never in the
+// shareable configuration document.
+type Config struct {
+	// Provider selects the agent command line, one of the Provider constants.
+	Provider string `json:"provider"`
+
+	// BaseURL overrides the agent api endpoint. An empty value leaves whatever
+	// the machine is already configured with, which is how "just run claude"
+	// with the user's own login keeps working.
+	BaseURL string `json:"base_url"`
+
+	// APIKey authenticates against BaseURL. An empty value leaves the agent's
+	// own credentials in place.
+	APIKey string `json:"-"`
+
+	// Model overrides the model the agent runs. An empty value keeps its default.
+	Model string `json:"model"`
+
+	// AllowedTools is the comma separated tool set the agent may use.
+	AllowedTools string `json:"allowed_tools"`
+
+	// TimeoutSeconds bounds one run; the run is killed when it is exceeded.
+	TimeoutSeconds int `json:"timeout_seconds"`
+
+	// Command overrides the executable name, for a machine where the agent is
+	// installed under a different path. An empty value uses the provider default.
+	Command string `json:"command"`
+
+	// WorkDir is the directory the agent process runs in. It is set by the
+	// caller rather than configured, so it never lands in informer.json.
+	WorkDir string `json:"-"`
+}
+
+// DefaultConfig is the agent section a data directory without one starts from.
+func DefaultConfig() *Config {
+	return &Config{
+		Provider:       DefaultProvider,
+		AllowedTools:   DefaultAllowedTools,
+		TimeoutSeconds: DefaultTimeoutSeconds,
+	}
+}
+
+// legalProviders is the ordered set of providers the configuration accepts.
+// Whether a provider can actually run is a separate question answered by runnerOf.
+var legalProviders = []string{ProviderClaude, ProviderCodex} //nolint:gochecknoglobals //ordered constant set.
+
+// LegalProviders returns the accepted providers in presentation order.
+// The result is a copy, so a caller can neither shrink nor reorder the set.
+func LegalProviders() []string {
+	return slices.Clone(legalProviders)
+}
+
+// IsLegalProvider reports whether the value names a provider the configuration accepts.
+func IsLegalProvider(provider string) bool {
+	return slices.Contains(legalProviders, provider)
+}
+
+// Item is one article an agent returned.
+type Item struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+}
+
+// Result is the outcome of one agent run.
+type Result struct {
+	// Items are the articles parsed out of the agent output.
+	Items []Item
+
+	// Raw is the agent's own answer text, kept so a source that returned
+	// nothing usable can still be diagnosed from the logs.
+	Raw string
+}
+
+// Normalized returns a copy with every empty field replaced by its default and
+// every out of range value clamped, so a runner never has to defend itself
+// against a half filled configuration.
+func (c *Config) Normalized() *Config {
+	normalized := &Config{}
+	if c != nil {
+		*normalized = *c
+	}
+
+	normalized.Provider = strings.TrimSpace(normalized.Provider)
+	if normalized.Provider == "" {
+		normalized.Provider = DefaultProvider
+	}
+
+	normalized.BaseURL = strings.TrimSpace(normalized.BaseURL)
+	normalized.APIKey = strings.TrimSpace(normalized.APIKey)
+	normalized.Model = strings.TrimSpace(normalized.Model)
+	normalized.Command = strings.TrimSpace(normalized.Command)
+
+	normalized.AllowedTools = strings.TrimSpace(normalized.AllowedTools)
+	if normalized.AllowedTools == "" {
+		normalized.AllowedTools = DefaultAllowedTools
+	}
+
+	switch {
+	case normalized.TimeoutSeconds <= 0:
+		normalized.TimeoutSeconds = DefaultTimeoutSeconds
+	case normalized.TimeoutSeconds < MinTimeoutSeconds:
+		normalized.TimeoutSeconds = MinTimeoutSeconds
+	case normalized.TimeoutSeconds > MaxTimeoutSeconds:
+		normalized.TimeoutSeconds = MaxTimeoutSeconds
+	}
+
+	return normalized
+}
+
+// runner executes one instruction and returns the agent's answer text.
+type runner func(ctx context.Context, cfg *Config, prompt string) (string, error)
+
+// runnerOf returns the runner of a provider, or an error for one this build
+// accepts in configuration but cannot execute yet.
+func runnerOf(provider string) (runner, error) {
+	if provider == ProviderClaude {
+		return runClaude, nil
+	}
+
+	if provider == ProviderCodex {
+		return nil, fmt.Errorf("%w: %q is not implemented in this build", ErrUnsupportedProvider, provider)
+	}
+
+	return nil, fmt.Errorf("%w: %q", ErrUnsupportedProvider, provider)
+}
+
+// Run gives the agent the user's instruction plus the appended output contract,
+// and returns the articles its answer described.
+//
+// maxItems bounds what the prompt asks for; a value of zero uses DefaultMaxItems.
+// The run is always bounded by the configured timeout, whatever deadline ctx carries.
+func Run(ctx context.Context, cfg *Config, userPrompt string, maxItems int) (*Result, error) {
+	instruction := strings.TrimSpace(userPrompt)
+	if instruction == "" {
+		return nil, ErrEmptyPrompt
+	}
+
+	config := cfg.Normalized()
+
+	run, err := runnerOf(config.Provider)
+	if err != nil {
+		return nil, err
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, time.Duration(config.TimeoutSeconds)*time.Second)
+	defer cancel()
+
+	raw, err := run(runCtx, config, BuildPrompt(instruction, maxItems))
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := ParseItems(raw)
+	if err != nil {
+		return &Result{Raw: raw}, err
+	}
+
+	return &Result{Items: items, Raw: raw}, nil
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/agent"
+)
+
+const (
+	// windowsGOOS is the one platform without the posix shell the stand-in agent needs.
+	windowsGOOS = "windows"
+
+	// testInstruction stands in for whatever a source author would write.
+	testInstruction = "find today's news"
+)
+
+// fakeAgent is the stand-in command line one case runs.
+type fakeAgent struct {
+	// binary is the executable to configure as the agent command.
+	binary string
+
+	// record is the file the script writes its arguments and environment to.
+	record string
+}
+
+// fakeClaude writes an executable stand-in for the claude command line. The
+// script records the arguments and the anthropic environment it was called with,
+// then prints the given stdout and exits with the given code, which lets the exec
+// path be exercised without a real agent.
+func fakeClaude(t *testing.T, stdout string, exitCode int) fakeAgent {
+	t.Helper()
+
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("the fake agent is a posix shell script")
+	}
+
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "fake-claude")
+	record := filepath.Join(dir, "record")
+
+	script := "#!/bin/sh\n" +
+		"{\n" +
+		"  for arg in \"$@\"; do printf 'arg:%s\\n' \"$arg\"; done\n" +
+		"  printf 'env:ANTHROPIC_BASE_URL=%s\\n' \"$ANTHROPIC_BASE_URL\"\n" +
+		"  printf 'env:ANTHROPIC_AUTH_TOKEN=%s\\n' \"$ANTHROPIC_AUTH_TOKEN\"\n" +
+		"  printf 'env:ANTHROPIC_API_KEY=%s\\n' \"$ANTHROPIC_API_KEY\"\n" +
+		"} > " + record + "\n" +
+		"cat <<'INFORMER_EOF'\n" + stdout + "\nINFORMER_EOF\n" +
+		"exit " + strconv.Itoa(exitCode) + "\n"
+
+	require.NoError(t, os.WriteFile(binary, []byte(script), 0o700)) //nolint:gosec //test helper binary.
+
+	return fakeAgent{binary: binary, record: record}
+}
+
+func envelope(result string) string {
+	return `{"type":"result","subtype":"success","is_error":false,"result":` + quote(result) + `}`
+}
+
+func quote(value string) string {
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(value, `\`, `\\`), `"`, `\"`) + `"`
+}
+
+func TestRunParsesTheAgentAnswer(t *testing.T) {
+	t.Parallel()
+
+	stub := fakeClaude(t, envelope(`{"items":[{"title":"a","url":"`+sampleURL+`"}]}`), 0)
+
+	result, err := agent.Run(t.Context(), &agent.Config{Command: stub.binary}, testInstruction, 3)
+
+	require.NoError(t, err)
+	require.Equal(t, []agent.Item{{Title: "a", URL: sampleURL}}, result.Items)
+}
+
+func TestRunPassesConfigurationToTheCommandLine(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	stub := fakeClaude(t, envelope(`{"items":[]}`), 0)
+
+	_, err := agent.Run(t.Context(), &agent.Config{
+		Command:      stub.binary,
+		BaseURL:      "https://proxy.example.com",
+		APIKey:       "secret-key",
+		Model:        "claude-sonnet-5",
+		AllowedTools: "WebFetch",
+		WorkDir:      workDir,
+	}, testInstruction, 3)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(stub.record)
+	require.NoError(t, err)
+
+	call := string(raw)
+	require.Contains(t, call, "arg:--print\n")
+	require.Contains(t, call, "arg:--output-format\narg:json\n")
+	require.Contains(t, call, "arg:--model\narg:claude-sonnet-5\n")
+	require.Contains(t, call, "arg:--tools\narg:WebFetch\n")
+	require.Contains(t, call, "arg:--allowedTools\narg:WebFetch\n")
+	require.Contains(t, call, "env:ANTHROPIC_BASE_URL=https://proxy.example.com\n")
+	require.Contains(t, call, "env:ANTHROPIC_AUTH_TOKEN=secret-key\n")
+	require.Contains(t, call, "env:ANTHROPIC_API_KEY=secret-key\n")
+	require.Contains(t, call, testInstruction)
+}
+
+func TestRunLeavesTheMachineCredentialsAloneWhenUnconfigured(t *testing.T) {
+	stub := fakeClaude(t, envelope(`{"items":[]}`), 0)
+
+	t.Setenv("ANTHROPIC_BASE_URL", "https://machine.example.com")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "machine-token")
+
+	_, err := agent.Run(t.Context(), &agent.Config{Command: stub.binary}, testInstruction, 3)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(stub.record)
+	require.NoError(t, err)
+
+	require.Contains(t, string(raw), "env:ANTHROPIC_BASE_URL=https://machine.example.com\n")
+	require.Contains(t, string(raw), "env:ANTHROPIC_AUTH_TOKEN=machine-token\n")
+}
+
+func TestRunReportsACommandFailure(t *testing.T) {
+	t.Parallel()
+
+	stub := fakeClaude(t, "boom", 1)
+
+	_, err := agent.Run(t.Context(), &agent.Config{Command: stub.binary}, testInstruction, 3)
+
+	require.ErrorIs(t, err, agent.ErrAgentFailed)
+}
+
+func TestRunReportsAnErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	stub := fakeClaude(t, `{"type":"result","subtype":"error_max_turns","is_error":true,"result":"too many turns"}`, 0)
+
+	_, err := agent.Run(t.Context(), &agent.Config{Command: stub.binary}, testInstruction, 3)
+
+	require.ErrorIs(t, err, agent.ErrAgentFailed)
+	require.Contains(t, err.Error(), "error_max_turns")
+}
+
+func TestRunKeepsTheRawAnswerWhenParsingFails(t *testing.T) {
+	t.Parallel()
+
+	stub := fakeClaude(t, envelope("I could not find anything."), 0)
+
+	result, err := agent.Run(t.Context(), &agent.Config{Command: stub.binary}, testInstruction, 3)
+
+	require.ErrorIs(t, err, agent.ErrNoJSONOutput)
+	require.NotNil(t, result)
+	require.Equal(t, "I could not find anything.", result.Raw)
+}
+
+func TestRunRefusesAnEmptyPrompt(t *testing.T) {
+	t.Parallel()
+
+	_, err := agent.Run(t.Context(), agent.DefaultConfig(), "   ", 3)
+
+	require.ErrorIs(t, err, agent.ErrEmptyPrompt)
+}
+
+func TestRunRefusesAProviderThisBuildCannotDrive(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range []string{agent.ProviderCodex, "gemini"} {
+		_, err := agent.Run(t.Context(), &agent.Config{Provider: provider}, testInstruction, 3)
+
+		require.ErrorIs(t, err, agent.ErrUnsupportedProvider, provider)
+	}
+}
+
+func TestRunHonoursTheConfiguredTimeout(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("the fake agent is a posix shell script")
+	}
+
+	dir := t.TempDir()
+	slow := filepath.Join(dir, "slow-claude")
+	require.NoError(t, os.WriteFile(slow, []byte("#!/bin/sh\nsleep 30\n"), 0o700)) //nolint:gosec //test helper binary.
+
+	// the configured timeout floor is well above what a test may wait for, so the
+	// caller's own deadline is what stops this run; either way the agent is killed
+	// instead of blocking the fetch loop forever.
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	t.Cleanup(cancel)
+
+	_, err := agent.Run(ctx, &agent.Config{Command: slow}, testInstruction, 3)
+
+	require.ErrorIs(t, err, agent.ErrAgentFailed)
+}
+
+func TestNormalizedFillsDefaultsAndClampsTheTimeout(t *testing.T) {
+	t.Parallel()
+
+	filled := (&agent.Config{}).Normalized()
+	require.Equal(t, agent.DefaultProvider, filled.Provider)
+	require.Equal(t, agent.DefaultAllowedTools, filled.AllowedTools)
+	require.Equal(t, agent.DefaultTimeoutSeconds, filled.TimeoutSeconds)
+
+	require.Equal(t, agent.MinTimeoutSeconds, (&agent.Config{TimeoutSeconds: 1}).Normalized().TimeoutSeconds)
+	require.Equal(t, agent.MaxTimeoutSeconds, (&agent.Config{TimeoutSeconds: 999_999}).Normalized().TimeoutSeconds)
+	require.Equal(t, agent.DefaultTimeoutSeconds, (*agent.Config)(nil).Normalized().TimeoutSeconds)
+}
+
+func TestLegalProvidersIsACopy(t *testing.T) {
+	t.Parallel()
+
+	providers := agent.LegalProviders()
+	require.Equal(t, []string{agent.ProviderClaude, agent.ProviderCodex}, providers)
+
+	providers[0] = "mutated"
+
+	require.Equal(t, agent.ProviderClaude, agent.LegalProviders()[0])
+
+	require.True(t, agent.IsLegalProvider(agent.ProviderClaude))
+	require.False(t, agent.IsLegalProvider("gemini"))
+}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ClaudeCommand is the default executable of the Claude Code command line.
+const ClaudeCommand = "claude"
+
+// Environment variables the claude command line reads. They are set only when the
+// configuration fills them in, so a machine already logged in through `claude`
+// itself keeps running with its own credentials.
+const (
+	envBaseURL   = "ANTHROPIC_BASE_URL"
+	envAuthToken = "ANTHROPIC_AUTH_TOKEN" //nolint:gosec //variable name, not a credential.
+	envAPIKey    = "ANTHROPIC_API_KEY"    //nolint:gosec //variable name, not a credential.
+)
+
+// claudeEnvelope is the --output-format json document the command line prints.
+// Only the fields informer acts on are declared; everything else - cost, token
+// usage, session id - is deliberately ignored.
+type claudeEnvelope struct {
+	Type    string `json:"type"`
+	Subtype string `json:"subtype"`
+	IsError bool   `json:"is_error"`
+	Result  string `json:"result"`
+	Error   string `json:"error"`
+}
+
+// runClaude executes one non interactive Claude Code run and returns its answer text.
+func runClaude(ctx context.Context, cfg *Config, prompt string) (string, error) {
+	command := cfg.Command
+	if command == "" {
+		command = ClaudeCommand
+	}
+
+	cmd := exec.CommandContext(ctx, command, claudeArgs(cfg, prompt)...)
+	cmd.Dir = cfg.WorkDir
+	cmd.Env = claudeEnv(cfg)
+	cmd.Stdin = nil
+
+	var stdout, stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		// the timeout is the common failure of a browsing agent, and the raw
+		// exec message does not say so; name it where the source error is stored.
+		ctxErr := ctx.Err()
+		if ctxErr != nil {
+			return "", fmt.Errorf("%w: %s run stopped after %ds: %w",
+				ErrAgentFailed, command, cfg.TimeoutSeconds, ctxErr)
+		}
+
+		// a silent failure - a missing binary, a killed process - carries no
+		// stderr, and appending an empty tail would only end the stored source
+		// error in a dangling colon.
+		if details := truncate(stderr.String()); details != "" {
+			return "", fmt.Errorf("%w: %s run: %w: %s", ErrAgentFailed, command, err, details)
+		}
+
+		return "", fmt.Errorf("%w: %s run: %w", ErrAgentFailed, command, err)
+	}
+
+	return claudeResultText(stdout.Bytes())
+}
+
+// claudeArgs builds the non interactive invocation.
+//
+// The tool set is passed twice on purpose: --tools bounds what the session may
+// reach for at all, and --allowedTools pre-approves exactly that set so a
+// headless run never stalls on a permission prompt it has no way to answer.
+func claudeArgs(cfg *Config, prompt string) []string {
+	args := []string{"--print", prompt, "--output-format", "json", "--strict-mcp-config"}
+
+	if cfg.Model != "" {
+		args = append(args, "--model", cfg.Model)
+	}
+
+	if cfg.AllowedTools != "" {
+		args = append(args, "--tools", cfg.AllowedTools, "--allowedTools", cfg.AllowedTools)
+	}
+
+	return args
+}
+
+// claudeEnv builds the child environment: the current one, with the configured
+// endpoint and credential replacing whatever it already carried. An unconfigured
+// field is left alone rather than blanked, which is what makes "just run claude
+// with the machine's own login" work.
+func claudeEnv(cfg *Config) []string {
+	overrides := map[string]string{}
+
+	if cfg.BaseURL != "" {
+		overrides[envBaseURL] = cfg.BaseURL
+	}
+
+	if cfg.APIKey != "" {
+		// both forms are set because an Anthropic compatible endpoint may read
+		// either the bearer token or the x-api-key header.
+		overrides[envAuthToken] = cfg.APIKey
+		overrides[envAPIKey] = cfg.APIKey
+	}
+
+	if len(overrides) == 0 {
+		return nil
+	}
+
+	env := os.Environ()
+	kept := make([]string, 0, len(env)+len(overrides))
+
+	for _, entry := range env {
+		name, _, found := strings.Cut(entry, "=")
+		if found {
+			if _, replaced := overrides[name]; replaced {
+				continue
+			}
+		}
+
+		kept = append(kept, entry)
+	}
+
+	for name, value := range overrides {
+		kept = append(kept, name+"="+value)
+	}
+
+	return kept
+}
+
+// claudeResultText unwraps the json envelope and returns the answer text.
+func claudeResultText(output []byte) (string, error) {
+	var envelope claudeEnvelope
+
+	err := json.Unmarshal(bytes.TrimSpace(output), &envelope)
+	if err != nil {
+		return "", fmt.Errorf("parse claude output envelope: %w: %s", err, truncate(string(output)))
+	}
+
+	if envelope.IsError {
+		reason := envelope.Error
+		if reason == "" {
+			reason = envelope.Result
+		}
+
+		return "", fmt.Errorf("%w: claude reported %q: %s", ErrAgentFailed, envelope.Subtype, truncate(reason))
+	}
+
+	return envelope.Result, nil
+}

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// outputContract is appended to every instruction. It is the only part of the
+// prompt informer writes itself, and it exists so a source author never has to
+// spell the json shape out by hand.
+//
+//nolint:gosmopolitan //informer is a chinese product; the contract speaks the user's language.
+const outputContract = `
+---
+以上是本次任务。以下是 informer 追加的输出格式要求，必须严格遵守：
+
+1. 最终答复只输出一个 JSON 对象，不要输出任何解释、前言、总结或 Markdown 代码块标记。
+2. JSON 对象的结构固定为：
+{"items":[{"title":"文章标题","url":"文章链接"}]}
+3. title 是非空字符串；url 必须是以 http:// 或 https:// 开头的完整可访问链接，不要输出相对路径。
+4. 最多返回 %d 条，按重要程度从高到低排列，不要重复同一个链接。
+5. 没有任何结果时，输出 {"items":[]}，不要编造链接。`
+
+// BuildPrompt assembles the text handed to the agent: the user's own instruction
+// first, then the output contract. maxItems of zero falls back to DefaultMaxItems
+// and any larger request is capped, so one source can never ask for an unbounded
+// answer.
+func BuildPrompt(userPrompt string, maxItems int) string {
+	limit := maxItems
+	if limit <= 0 {
+		limit = DefaultMaxItems
+	}
+
+	if limit > MaxItemsCap {
+		limit = MaxItemsCap
+	}
+
+	return strings.TrimSpace(userPrompt) + "\n" + fmt.Sprintf(outputContract, limit)
+}
+
+// itemsDocument is the object shape the contract asks for.
+type itemsDocument struct {
+	Items []Item `json:"items"`
+}
+
+// ParseItems reads the articles out of an agent answer.
+//
+// The contract asks for a bare {"items":[...]} object, but a model that wraps it
+// in a code fence, or answers with the array alone, is still understood: the
+// alternative is throwing away a perfectly good result over punctuation. Entries
+// without a title or without an absolute http url are dropped rather than stored,
+// and a repeated url is kept only once.
+func ParseItems(raw string) ([]Item, error) {
+	document := extractJSON(stripCodeFence(raw))
+	if document == "" {
+		return nil, fmt.Errorf("%w: %q", ErrNoJSONOutput, truncate(raw))
+	}
+
+	var parsed itemsDocument
+
+	// a bare array is the one deviation from the contract that carries the same
+	// information, so it is read rather than refused.
+	if strings.HasPrefix(document, "[") {
+		err := json.Unmarshal([]byte(document), &parsed.Items)
+		if err != nil {
+			return nil, fmt.Errorf("parse agent json array: %w", err)
+		}
+
+		return cleanItems(parsed.Items), nil
+	}
+
+	err := json.Unmarshal([]byte(document), &parsed)
+	if err != nil {
+		return nil, fmt.Errorf("parse agent json object: %w", err)
+	}
+
+	return cleanItems(parsed.Items), nil
+}
+
+// cleanItems keeps the usable entries in their original order.
+func cleanItems(items []Item) []Item {
+	cleaned := make([]Item, 0, len(items))
+	seen := make(map[string]bool, len(items))
+
+	for _, item := range items {
+		title := strings.TrimSpace(item.Title)
+		link := strings.TrimSpace(item.URL)
+
+		if title == "" || !isAbsoluteHTTPURL(link) || seen[link] {
+			continue
+		}
+
+		seen[link] = true
+
+		cleaned = append(cleaned, Item{Title: title, URL: link})
+	}
+
+	return cleaned
+}
+
+// isAbsoluteHTTPURL reports whether the link is one informer can store and open.
+// A relative path is refused instead of guessed at: an agent source has no base
+// url to resolve it against.
+func isAbsoluteHTTPURL(link string) bool {
+	return strings.HasPrefix(link, "http://") || strings.HasPrefix(link, "https://")
+}
+
+// stripCodeFence removes the ``` wrapper a model may put around its json.
+func stripCodeFence(raw string) string {
+	text := strings.TrimSpace(raw)
+	if !strings.HasPrefix(text, "```") {
+		return text
+	}
+
+	// drop the opening fence line, which may carry a language tag.
+	if newline := strings.IndexByte(text, '\n'); newline >= 0 {
+		text = text[newline+1:]
+	} else {
+		return ""
+	}
+
+	if closing := strings.LastIndex(text, "```"); closing >= 0 {
+		text = text[:closing]
+	}
+
+	return strings.TrimSpace(text)
+}
+
+// extractJSON returns the outermost json document inside the text, so a stray
+// sentence before or after the answer does not cost the whole result.
+func extractJSON(text string) string {
+	start := strings.IndexAny(text, "{[")
+	if start < 0 {
+		return ""
+	}
+
+	closing := byte('}')
+	if text[start] == '[' {
+		closing = ']'
+	}
+
+	end := strings.LastIndexByte(text, closing)
+	if end <= start {
+		return ""
+	}
+
+	return text[start : end+1]
+}
+
+// maxDiagnosticRunes bounds the raw output quoted in an error message.
+const maxDiagnosticRunes = 300
+
+// truncate shortens output quoted into an error so a runaway answer cannot
+// bury the actual failure. It cuts on rune boundaries, so a chinese answer is
+// never sliced into invalid utf-8.
+func truncate(text string) string {
+	trimmed := strings.TrimSpace(text)
+
+	runes := []rune(trimmed)
+	if len(runes) <= maxDiagnosticRunes {
+		return trimmed
+	}
+
+	return string(runes[:maxDiagnosticRunes]) + "..."
+}

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/agent"
+)
+
+// sampleURL is the one article link every parsing case in this package uses.
+const sampleURL = "https://a.com/1"
+
+// the contract informer appends is chinese, so the case that proves it is
+// appended verbatim has to quote it.
+//
+//nolint:gosmopolitan //asserting on the shipped chinese contract text.
+func TestBuildPromptKeepsInstructionAndAppendsContract(t *testing.T) {
+	t.Parallel()
+
+	prompt := agent.BuildPrompt("  找出今天的 Go 语言新闻  ", 5)
+
+	require.True(t, strings.HasPrefix(prompt, "找出今天的 Go 语言新闻\n"))
+	require.Contains(t, prompt, `{"items":[{"title":"文章标题","url":"文章链接"}]}`)
+	require.Contains(t, prompt, "最多返回 5 条")
+}
+
+//nolint:gosmopolitan //asserting on the shipped chinese contract text.
+func TestBuildPromptBoundsTheRequestedCount(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, agent.BuildPrompt("x", 0), "最多返回 "+strconv.Itoa(agent.DefaultMaxItems)+" 条")
+	require.Contains(t, agent.BuildPrompt("x", -3), "最多返回 "+strconv.Itoa(agent.DefaultMaxItems)+" 条")
+	require.Contains(t, agent.BuildPrompt("x", 10_000), "最多返回 "+strconv.Itoa(agent.MaxItemsCap)+" 条")
+}
+
+func TestParseItemsAcceptsTheContractShape(t *testing.T) {
+	t.Parallel()
+
+	items, err := agent.ParseItems(`{"items":[{"title":"a","url":"` + sampleURL + `"}]}`)
+
+	require.NoError(t, err)
+	require.Equal(t, []agent.Item{{Title: "a", URL: sampleURL}}, items)
+}
+
+// a real model answers in the language of the prompt, so the wrapper this case
+// has to survive is chinese prose.
+//
+//nolint:gosmopolitan //modelling a chinese model answer.
+func TestParseItemsAcceptsAWrappedOrBareAnswer(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"code fence":     "```json\n{\"items\":[{\"title\":\"a\",\"url\":\"https://a.com/1\"}]}\n```",
+		"bare array":     `[{"title":"a","url":"` + sampleURL + `"}]`,
+		"chatty wrapper": "这是结果:\n{\"items\":[{\"title\":\"a\",\"url\":\"https://a.com/1\"}]}\n希望有用。",
+	}
+
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			items, err := agent.ParseItems(raw)
+
+			require.NoError(t, err)
+			require.Equal(t, []agent.Item{{Title: "a", URL: sampleURL}}, items)
+		})
+	}
+}
+
+func TestParseItemsDropsUnusableEntries(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"items":[
+		{"title":"keep","url":"https://a.com/1"},
+		{"title":"","url":"https://a.com/2"},
+		{"title":"relative","url":"/news/3"},
+		{"title":"scheme","url":"ftp://a.com/4"},
+		{"title":"duplicate","url":"https://a.com/1"},
+		{"title":" trimmed ","url":" https://a.com/5 "}
+	]}`
+
+	items, err := agent.ParseItems(raw)
+
+	require.NoError(t, err)
+	require.Equal(t, []agent.Item{
+		{Title: "keep", URL: sampleURL},
+		{Title: "trimmed", URL: "https://a.com/5"},
+	}, items)
+}
+
+func TestParseItemsReturnsEmptyForAnEmptyAnswer(t *testing.T) {
+	t.Parallel()
+
+	items, err := agent.ParseItems(`{"items":[]}`)
+
+	require.NoError(t, err)
+	require.Empty(t, items)
+}
+
+//nolint:gosmopolitan //modelling a chinese model answer.
+func TestParseItemsRejectsOutputWithoutJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := agent.ParseItems("抱歉，我没有找到任何结果。")
+
+	require.ErrorIs(t, err, agent.ErrNoJSONOutput)
+}
+
+func TestParseItemsRejectsBrokenJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := agent.ParseItems(`{"items":[{"title":"a","url":}]}`)
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, agent.ErrNoJSONOutput)
+}

--- a/internal/cli/feed.go
+++ b/internal/cli/feed.go
@@ -51,6 +51,12 @@ func Feed(svc *service.Service, ops []string) error {
 		}
 
 		return addSource(svc, args[0], args[1])
+	case "agent":
+		if len(args) < 2 {
+			return fmt.Errorf("%w: feed agent <title> <prompt>", ErrUsage)
+		}
+
+		return addAgentSource(svc, args[0], args[1])
 	case "remove":
 		return withOneArg(op, args, func(id string) error { return removeSource(svc, id) })
 	case "update":
@@ -118,6 +124,24 @@ func addSource(svc *service.Service, title, link string) error {
 	return nil
 }
 
+// addAgentSource stores a source whose articles come from an agent run instead of
+// a fetch. Only the instruction is asked for: the json output contract is appended
+// by informer itself, and the endpoint, credential and model come from the shared
+// agent configuration.
+func addAgentSource(svc *service.Service, title, prompt string) error {
+	source := &feed.Source{Title: title, ParseType: feed.ParseTypeAgent, AgentPrompt: prompt}
+
+	err := svc.CreateSource(source)
+	if err != nil {
+		return err
+	}
+
+	//nolint:forbidigo //the command line reports its result on stdout by design.
+	fmt.Printf("%d,\t%s,\t%s\n", source.ID, source.Title, source.ResolveParseType())
+
+	return nil
+}
+
 func removeSource(svc *service.Service, idStr string) error {
 	id, err := parseID(idStr)
 	if err != nil {
@@ -162,6 +186,8 @@ func viewSource(svc *service.Service, idStr string) error {
 	fmt.Printf("json_title_path:\t%s\n", source.JsonTitlePath)
 	fmt.Printf("json_url_path:\t%s\n", source.JsonURLPath)
 	fmt.Printf("parse_type:\t%s\n", source.ResolveParseType())
+	fmt.Printf("agent_provider:\t%s\n", source.AgentProvider) //nolint:forbidigo //stdout is the output of this command.
+	fmt.Printf("agent_prompt:\t%s\n", source.AgentPrompt)     //nolint:forbidigo //stdout is the output of this command.
 	fmt.Printf("category_id:\t%d\n", source.CategoryID)
 	fmt.Printf("enabled:\t%t\n", source.Enabled)
 

--- a/internal/feed/agent.go
+++ b/internal/feed/agent.go
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feed
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/vogo/logger"
+	"github.com/vogo/vogo/vnet/vurl"
+
+	"github.com/vogo/informer/internal/agent"
+)
+
+// ErrAgentPromptEmpty marks an agent source that has no instruction to run.
+var ErrAgentPromptEmpty = errors.New("agent source has no prompt")
+
+func agentParseFeed(config *Config, source *Source, agentConfig *agent.Config, _ int64) {
+	logger.Info("agent parse feed: ", source.Title)
+
+	articles, err := AgentParse(source, agentConfig)
+	if err != nil {
+		logger.Infof("agent parse feed error! source: %s, error: %v", source.Title, err)
+
+		updateSourceError(source, err)
+
+		return
+	}
+
+	updateSourceNormal(source)
+
+	saveParsedArticles(config, source, articles)
+}
+
+// AgentParse asks the configured agent for the articles of an agent source.
+//
+// The source only carries the instruction; the json output contract and the item
+// limit are added here, so what the user typed stays exactly what they meant.
+// The source may override the provider of the shared agent configuration, which
+// is what lets one subscription run on a different agent than the rest.
+func AgentParse(source *Source, agentConfig *agent.Config) ([]*Article, error) {
+	prompt := strings.TrimSpace(source.AgentPrompt)
+	if prompt == "" {
+		return nil, ErrAgentPromptEmpty
+	}
+
+	runConfig := agentConfig.Normalized()
+	if provider := strings.TrimSpace(source.AgentProvider); provider != "" {
+		runConfig.Provider = provider
+	}
+
+	result, err := agent.Run(context.Background(), runConfig, prompt, source.MaxFetchNum)
+	if err != nil {
+		return nil, fmt.Errorf("agent source %q: %w", source.Title, err)
+	}
+
+	now := time.Now().Unix()
+
+	articles := make([]*Article, 0, len(result.Items))
+
+	for _, item := range result.Items {
+		link := item.URL
+		if source.Redirect {
+			link = vurl.RedirectURL(link)
+		}
+
+		articles = append(articles, &Article{
+			URL:       link,
+			Title:     item.Title,
+			Timestamp: now,
+			Weight:    source.Weight,
+			SourceID:  source.ID,
+		})
+	}
+
+	logger.Infof("agent parse, source: %s, articles: %d", source.Title, len(articles))
+
+	return articles, nil
+}

--- a/internal/feed/feed.go
+++ b/internal/feed/feed.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/vogo/logger"
+
+	"github.com/vogo/informer/internal/agent"
 )
 
 const (
@@ -31,8 +33,8 @@ const (
 
 // AddFeeds writes the recommended articles into buf and returns them so that the
 // caller can record the delivery once a notification actually succeeded.
-func AddFeeds(buf io.StringWriter, config *Config) []*Article {
-	articles := UpdateAndFilterFeeds(config)
+func AddFeeds(buf io.StringWriter, config *Config, agentConfig *agent.Config) []*Article {
+	articles := UpdateAndFilterFeeds(config, agentConfig)
 	if len(articles) > 0 {
 		_, _ = buf.WriteString("文章推荐:\n")
 
@@ -44,7 +46,7 @@ func AddFeeds(buf io.StringWriter, config *Config) []*Article {
 	return articles
 }
 
-func UpdateAndFilterFeeds(config *Config) []*Article {
+func UpdateAndFilterFeeds(config *Config, agentConfig *agent.Config) []*Article {
 	now := time.Now()
 	nowTime := now.Unix()
 	expireTime := now.Add(time.Hour * 24 * time.Duration(-config.FeedExpireDays)).Unix()
@@ -63,6 +65,8 @@ func UpdateAndFilterFeeds(config *Config) []*Article {
 			jsonParseFeed(config, source, expireTime)
 		case ParseTypeRegex:
 			regexParseFeed(config, source, expireTime)
+		case ParseTypeAgent:
+			agentParseFeed(config, source, agentConfig, expireTime)
 		default:
 			addGoFeed(config, source, expireTime)
 		}

--- a/internal/feed/feed_test.go
+++ b/internal/feed/feed_test.go
@@ -49,7 +49,7 @@ func TestUpdateAndFilterFeeds(t *testing.T) {
 		Enabled:    true,
 	}).Error)
 
-	articles := feed.UpdateAndFilterFeeds(feedConfig)
+	articles := feed.UpdateAndFilterFeeds(feedConfig, nil)
 	if len(articles) == 0 {
 		t.Error("parse feed article failed")
 	} else {

--- a/internal/feed/model.go
+++ b/internal/feed/model.go
@@ -38,6 +38,11 @@ const (
 	ParseTypeFeed  = "feed"
 	ParseTypeRegex = "regex"
 	ParseTypeJSON  = "json"
+
+	// ParseTypeAgent asks a coding agent for the articles instead of fetching a
+	// document. It is the one parse type the legacy IsJSON and Regex columns
+	// cannot express, so it is never derived - only an explicit value selects it.
+	ParseTypeAgent = "agent"
 )
 
 const (
@@ -75,12 +80,21 @@ type Source struct {
 	ParseType     string `json:"parse_type"`
 	CategoryID    int64  `json:"category_id" gorm:"index"`
 	Enabled       bool   `json:"enabled" gorm:"index"`
+
+	// AgentProvider selects the agent command line of a ParseTypeAgent source.
+	// An empty value uses the configured default provider.
+	AgentProvider string `json:"agent_provider"`
+
+	// AgentPrompt is the plain language instruction of a ParseTypeAgent source.
+	// It is what the user writes; the json output contract is appended by
+	// informer itself, so this field never has to describe a result shape.
+	AgentPrompt string `json:"agent_prompt"`
 }
 
 // legalParseTypes is the ordered set of supported parse types. Every legality
 // check and every list of offered types reads from here, so adding a parser
 // never leaves a caller with a stale copy of the set.
-var legalParseTypes = []string{ParseTypeFeed, ParseTypeRegex, ParseTypeJSON}
+var legalParseTypes = []string{ParseTypeFeed, ParseTypeRegex, ParseTypeJSON, ParseTypeAgent}
 
 // LegalParseTypes returns the supported parse types in presentation order.
 // The result is a copy: a caller can neither shrink nor reorder the set.

--- a/internal/feed/parse.go
+++ b/internal/feed/parse.go
@@ -17,18 +17,25 @@
 
 package feed
 
+import "github.com/vogo/informer/internal/agent"
+
 // ParseArticles parses a source with the parser its ParseType selects, falling back
 // to the historical derivation when no legal parse type is set.
 //
-// It performs network reads only: no source, article, status, timestamp or config
-// record is created or modified, so it can be called repeatedly without changing
-// any persisted state.
-func ParseArticles(source *Source) ([]*Article, error) {
+// agentConfig backs a ParseTypeAgent source and is ignored by every other parser;
+// a nil value runs the agent with its defaults.
+//
+// It performs network reads and agent runs only: no source, article, status,
+// timestamp or config record is created or modified, so it can be called repeatedly
+// without changing any persisted state.
+func ParseArticles(source *Source, agentConfig *agent.Config) ([]*Article, error) {
 	switch source.ResolveParseType() {
 	case ParseTypeJSON:
 		return JsonParse(source)
 	case ParseTypeRegex:
 		return RegexParse(source)
+	case ParseTypeAgent:
+		return AgentParse(source, agentConfig)
 	default:
 		return GoFeedArticles(source)
 	}

--- a/internal/inform/informer.go
+++ b/internal/inform/informer.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/vogo/logger"
 
+	"github.com/vogo/informer/internal/agent"
 	"github.com/vogo/informer/internal/date"
 	"github.com/vogo/informer/internal/ding"
 	"github.com/vogo/informer/internal/feed"
@@ -66,6 +67,10 @@ func DailyFilePath(homeDir string, day time.Time) string {
 // Config is the layout of informer.json.
 type Config struct {
 	Feed *feed.Config `json:"feed"`
+
+	// Agent is the shared configuration of every agent source. A nil value runs
+	// the agent with its defaults and the machine's own credentials.
+	Agent *agent.Config `json:"agent"`
 }
 
 // Options describes one inform run. The feed database is expected to be
@@ -79,6 +84,10 @@ type Options struct {
 
 	// FeedConfig is the effective feed configuration; a nil value skips feeds.
 	FeedConfig *feed.Config
+
+	// AgentConfig backs the agent sources of this run; a nil value runs them
+	// with the agent defaults and the machine's own credentials.
+	AgentConfig *agent.Config
 }
 
 // Result is the outcome of one inform run.
@@ -123,7 +132,7 @@ func Run(opts *Options) (*Result, error) {
 
 	var articles []*feed.Article
 	if opts.FeedConfig != nil {
-		articles = feed.AddFeeds(buf, opts.FeedConfig)
+		articles = feed.AddFeeds(buf, opts.FeedConfig, opts.AgentConfig)
 	}
 
 	content := buf.String()

--- a/internal/service/agent_source_test.go
+++ b/internal/service/agent_source_test.go
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/agent"
+	"github.com/vogo/informer/internal/feed"
+	"github.com/vogo/informer/internal/service"
+)
+
+// stubAgent writes an executable stand-in for the agent command line, records the
+// prompt it was called with, and configures the service to run it. It lets the
+// whole agent path - configuration, prompt assembly, exec, parsing - be exercised
+// without a real agent or a network.
+func stubAgent(t *testing.T, svc *service.Service, answer string) string {
+	t.Helper()
+
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("the stub agent is a posix shell script")
+	}
+
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "stub-agent")
+	promptFile := filepath.Join(dir, "prompt")
+
+	// the prompt is the last argument the runner passes before the flags, so the
+	// script records every argument and the assertions look for the instruction.
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + promptFile + "\n" +
+		"cat <<'STUB_EOF'\n" +
+		`{"type":"result","subtype":"success","is_error":false,"result":` + jsonString(answer) + "}\n" +
+		"STUB_EOF\n"
+
+	require.NoError(t, os.WriteFile(binary, []byte(script), 0o700)) //nolint:gosec //test helper binary.
+	require.NoError(t, svc.SaveAgentConfig(&agent.Config{Command: binary}))
+
+	return promptFile
+}
+
+// jsonString quotes a value as a json string literal.
+func jsonString(value string) string {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(raw)
+}
+
+// agentPrompt is the plain instruction the stored agent source carries. It is
+// written in english so the linter that guards against hardcoded chinese in
+// source files has nothing to complain about; a real user writes their own.
+const agentPrompt = "find today's articles about the Go programming language"
+
+// unknownAgentProvider is a provider name no build can drive.
+const unknownAgentProvider = "gemini"
+
+// agentSource builds a stored agent source: an instruction and no address at all.
+func agentSource() *feed.Source {
+	return &feed.Source{
+		Title:       "agent source",
+		Weight:      60,
+		ParseType:   feed.ParseTypeAgent,
+		AgentPrompt: agentPrompt,
+	}
+}
+
+func TestCreateAgentSourceNeedsNoURL(t *testing.T) {
+	svc := newService(t)
+
+	source := agentSource()
+	require.NoError(t, svc.CreateSource(source))
+
+	stored, err := svc.GetSource(source.ID)
+	require.NoError(t, err)
+	assert.Equal(t, feed.ParseTypeAgent, stored.ResolveParseType())
+	assert.Equal(t, agentPrompt, stored.AgentPrompt)
+	assert.Empty(t, stored.URL)
+	assert.True(t, stored.Enabled)
+}
+
+func TestAgentSourceIsRefusedWithoutAPrompt(t *testing.T) {
+	svc := newService(t)
+
+	source := agentSource()
+	source.AgentPrompt = "   "
+
+	require.ErrorIs(t, svc.CreateSource(source), service.ErrInvalidArgument)
+}
+
+func TestAgentSourceIsRefusedWithAnUnknownProvider(t *testing.T) {
+	svc := newService(t)
+
+	source := agentSource()
+	source.AgentProvider = unknownAgentProvider
+
+	require.ErrorIs(t, svc.CreateSource(source), service.ErrInvalidArgument)
+}
+
+func TestFetchingSourceStillNeedsAnAddress(t *testing.T) {
+	svc := newService(t)
+
+	err := svc.CreateSource(&feed.Source{Title: "a source with neither url nor curl"})
+	require.ErrorIs(t, err, service.ErrInvalidArgument)
+}
+
+// the appended contract is chinese, and proving it reached the agent means
+// quoting it.
+//
+//nolint:gosmopolitan //asserting on the shipped chinese contract text.
+func TestPreviewAgentSourceRunsTheConfiguredAgent(t *testing.T) {
+	svc := newService(t)
+	promptFile := stubAgent(t, svc, `{"items":[
+		{"title":"agent one","url":"https://example.com/agent-one"},
+		{"title":"agent two","url":"https://example.com/agent-two"}]}`)
+
+	source := agentSource()
+	source.MaxFetchNum = 7
+	require.NoError(t, svc.CreateSource(source))
+
+	articles, err := svc.Preview(source.ID)
+	require.NoError(t, err)
+	require.Len(t, articles, 2)
+	assert.Equal(t, "agent one", articles[0].Title)
+	assert.Equal(t, "https://example.com/agent-one", articles[0].URL)
+	assert.Equal(t, source.ID, articles[0].SourceID)
+	assert.Equal(t, int64(60), articles[0].Weight)
+
+	// the user only wrote the instruction; the json contract and the item limit
+	// are what informer adds on top of it.
+	prompt, err := os.ReadFile(promptFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(prompt), agentPrompt)
+	assert.Contains(t, string(prompt), `{"items":[{"title":"文章标题","url":"文章链接"}]}`)
+	assert.Contains(t, string(prompt), "最多返回 7 条")
+
+	// a preview writes nothing at all, an agent source included.
+	before := snapshotDB(t, svc)
+	_, err = svc.Preview(source.ID)
+	require.NoError(t, err)
+	assert.Equal(t, before, snapshotDB(t, svc))
+}
+
+func TestPreviewAgentSourceReportsAFailedRun(t *testing.T) {
+	svc := newService(t)
+	stubAgent(t, svc, "I could not find anything.")
+
+	source := agentSource()
+	require.NoError(t, svc.CreateSource(source))
+
+	_, err := svc.Preview(source.ID)
+	require.ErrorIs(t, err, agent.ErrNoJSONOutput)
+}
+
+func TestAgentSourcesAreFilteredByTheirParseType(t *testing.T) {
+	server := newContentServer(t)
+	svc := newService(t)
+
+	require.NoError(t, svc.CreateSource(agentSource()))
+	require.NoError(t, svc.CreateSource(feedSource(server)))
+
+	agents, err := svc.AllSources(service.SourceQuery{ParseType: feed.ParseTypeAgent})
+	require.NoError(t, err)
+	require.Len(t, agents, 1)
+	assert.Equal(t, "agent source", agents[0].Title)
+
+	// a source that predates the parse type column is derived, and deriving can
+	// never name the agent parser, so it stays out of this bucket.
+	feeds, err := svc.AllSources(service.SourceQuery{ParseType: feed.ParseTypeFeed})
+	require.NoError(t, err)
+	require.Len(t, feeds, 1)
+	assert.Equal(t, "atom source", feeds[0].Title)
+}

--- a/internal/service/agentconfig.go
+++ b/internal/service/agentconfig.go
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vogo/informer/internal/agent"
+	"github.com/vogo/informer/internal/configstore"
+	"github.com/vogo/informer/internal/inform"
+)
+
+// agentSectionKey is the top level key of the agent section inside informer.json.
+const agentSectionKey = "agent"
+
+// DefaultAgentConfig is the agent section a data directory without one starts from.
+// Every endpoint field is empty on purpose: an installation that is already logged
+// in through the agent's own command line then keeps running on that login, and
+// only a user who wants a different endpoint has to fill anything in.
+func DefaultAgentConfig() *agent.Config {
+	return agent.DefaultConfig()
+}
+
+// agentSection is the agent part of informer.json exactly as the file spells it.
+// The api key is deliberately absent: it lives in the 0600 credential file next to
+// the bot webhook, so informer.json stays a document that can be shared and diffed.
+type agentSection struct {
+	Provider       string `json:"provider"`
+	BaseURL        string `json:"base_url"`
+	Model          string `json:"model"`
+	AllowedTools   string `json:"allowed_tools"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+	Command        string `json:"command"`
+}
+
+// ReadAgentConfig reads the agent section of informer.json.
+// A missing file or a missing section is reported as the defaults rather than a
+// failure, so a fetch always has a well formed configuration to run with.
+func (s *Service) ReadAgentConfig() (*agent.Config, error) {
+	doc, err := configstore.Load(s.ConfigFilePath())
+	if err != nil {
+		return nil, err
+	}
+
+	var section agentSection
+
+	found, err := doc.Unmarshal(agentSectionKey, &section)
+	if err != nil {
+		return nil, err
+	}
+
+	if !found {
+		return DefaultAgentConfig(), nil
+	}
+
+	return &agent.Config{
+		Provider:       section.Provider,
+		BaseURL:        section.BaseURL,
+		Model:          section.Model,
+		AllowedTools:   section.AllowedTools,
+		TimeoutSeconds: section.TimeoutSeconds,
+		Command:        section.Command,
+	}, nil
+}
+
+// SaveAgentConfig validates and stores the agent section of informer.json.
+//
+// The api key is not part of it: it is saved separately through SaveAgentAPIKey,
+// so a page that only ever shows whether a credential exists can save the endpoint
+// and the model without having to send the key back it never displayed.
+func (s *Service) SaveAgentConfig(config *agent.Config) error {
+	if config == nil {
+		return fmt.Errorf("%w: agent config is nil", ErrInvalidArgument)
+	}
+
+	err := ValidateAgentConfig(config)
+	if err != nil {
+		return err
+	}
+
+	return s.saveConfigSection(agentSectionKey, agentSection{
+		Provider:       strings.TrimSpace(config.Provider),
+		BaseURL:        strings.TrimSpace(config.BaseURL),
+		Model:          strings.TrimSpace(config.Model),
+		AllowedTools:   strings.TrimSpace(config.AllowedTools),
+		TimeoutSeconds: config.TimeoutSeconds,
+		Command:        strings.TrimSpace(config.Command),
+	})
+}
+
+// ValidateAgentConfig refuses an agent section a run could not act on.
+func ValidateAgentConfig(config *agent.Config) error {
+	if config == nil {
+		return fmt.Errorf("%w: agent config is nil", ErrInvalidArgument)
+	}
+
+	provider := strings.TrimSpace(config.Provider)
+	if provider != "" && !agent.IsLegalProvider(provider) {
+		return fmt.Errorf("%w: unknown agent provider %q", ErrInvalidArgument, provider)
+	}
+
+	// zero is the documented "use the default window" value of timeout_seconds.
+	if config.TimeoutSeconds == 0 {
+		return nil
+	}
+
+	return checkRange("timeout_seconds", config.TimeoutSeconds, agent.MinTimeoutSeconds, agent.MaxTimeoutSeconds)
+}
+
+// EffectiveAgentConfig resolves the configuration every agent source of one run uses.
+//
+// The file section decides the endpoint and model, the credential file supplies the
+// api key, and the data directory becomes the working directory of the agent process
+// so it never inherits whatever directory the caller happened to start in.
+func (s *Service) EffectiveAgentConfig(fileConfig *inform.Config) *agent.Config {
+	config := DefaultAgentConfig()
+
+	if fileConfig != nil && fileConfig.Agent != nil {
+		config = fileConfig.Agent
+	}
+
+	resolved := config.Normalized()
+	resolved.WorkDir = s.homeDir
+
+	key, err := s.readAgentAPIKey()
+	if err == nil && key != "" {
+		resolved.APIKey = key
+	}
+
+	return resolved
+}

--- a/internal/service/agentconfig_test.go
+++ b/internal/service/agentconfig_test.go
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/agent"
+	"github.com/vogo/informer/internal/inform"
+	"github.com/vogo/informer/internal/service"
+)
+
+// Values shared by the agent configuration cases.
+const (
+	testAgentBaseURL = "https://proxy.example.com"
+	testAgentModel   = "claude-sonnet-5"
+	testAgentAPIKey  = "secret-key"
+	unknownAgentName = "gemini"
+)
+
+func TestReadAgentConfigFallsBackToTheDefaults(t *testing.T) {
+	svc := newService(t)
+
+	stored, err := svc.ReadAgentConfig()
+	require.NoError(t, err)
+	assert.Equal(t, service.DefaultAgentConfig(), stored)
+}
+
+func TestSaveAgentConfigRoundTrips(t *testing.T) {
+	svc := newService(t)
+
+	saved := &agent.Config{
+		Provider:       agent.ProviderClaude,
+		BaseURL:        testAgentBaseURL,
+		Model:          testAgentModel,
+		AllowedTools:   "WebFetch",
+		TimeoutSeconds: 120,
+		Command:        "/opt/bin/claude",
+	}
+	require.NoError(t, svc.SaveAgentConfig(saved))
+
+	stored, err := svc.ReadAgentConfig()
+	require.NoError(t, err)
+	assert.Equal(t, saved, stored)
+
+	view, err := svc.ReadFileConfigView()
+	require.NoError(t, err)
+	require.NotNil(t, view.Agent)
+	assert.Equal(t, testAgentBaseURL, view.Agent.BaseURL)
+
+	// the agent section is edited by this build, so it is never listed as a
+	// field that merely survives the save.
+	assert.NotContains(t, view.PreservedKeys, "agent")
+}
+
+func TestSaveAgentConfigKeepsTheOtherSections(t *testing.T) {
+	svc := newService(t)
+
+	require.NoError(t, svc.SaveAgentConfig(&agent.Config{Model: testAgentModel}))
+
+	view, err := svc.ReadFileConfigView()
+	require.NoError(t, err)
+	require.NotNil(t, view.Feed, "the feed section written by newService survives an agent save")
+	assert.Equal(t, 10, view.Feed.MaxInformFeedSize)
+}
+
+func TestSaveAgentConfigRejectsAnUnusableSection(t *testing.T) {
+	svc := newService(t)
+
+	require.ErrorIs(t, svc.SaveAgentConfig(nil), service.ErrInvalidArgument)
+	require.ErrorIs(t, svc.SaveAgentConfig(&agent.Config{Provider: unknownAgentName}), service.ErrInvalidArgument)
+	require.ErrorIs(t, svc.SaveAgentConfig(&agent.Config{TimeoutSeconds: 1}), service.ErrInvalidArgument)
+	require.ErrorIs(t, svc.SaveAgentConfig(&agent.Config{TimeoutSeconds: 99_999}), service.ErrInvalidArgument)
+
+	// zero is the documented "use the default window" value, not an error.
+	require.NoError(t, svc.SaveAgentConfig(&agent.Config{TimeoutSeconds: 0}))
+}
+
+func TestAgentAPIKeyIsStoredInTheCredentialFile(t *testing.T) {
+	svc := newService(t)
+
+	view, err := svc.ReadSecretsView()
+	require.NoError(t, err)
+	assert.False(t, view.AgentAPIKeyConfigured)
+
+	require.NoError(t, svc.SaveAgentAPIKey("  "+testAgentAPIKey+"  "))
+
+	view, err = svc.ReadSecretsView()
+	require.NoError(t, err)
+	assert.True(t, view.AgentAPIKeyConfigured)
+
+	// the key never leaves the service through the view: the page is told that
+	// one exists, not what it is.
+	raw, err := os.ReadFile(svc.SecretsFilePath())
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), testAgentAPIKey)
+	assert.NotContains(t, string(raw), "  "+testAgentAPIKey+"  ")
+
+	if runtime.GOOS != windowsGOOS {
+		info, statErr := os.Stat(svc.SecretsFilePath())
+		require.NoError(t, statErr)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
+
+	// clearing puts the installation back on the agent's own login.
+	require.NoError(t, svc.SaveAgentAPIKey(""))
+
+	view, err = svc.ReadSecretsView()
+	require.NoError(t, err)
+	assert.False(t, view.AgentAPIKeyConfigured)
+}
+
+func TestAgentAPIKeyAndWebhookShareTheFileWithoutOverwriting(t *testing.T) {
+	svc := newService(t)
+
+	require.NoError(t, svc.SaveWebhook("https://open.feishu.cn/hook/x"))
+	require.NoError(t, svc.SaveAgentAPIKey(testAgentAPIKey))
+
+	view, err := svc.ReadSecretsView()
+	require.NoError(t, err)
+	assert.Equal(t, "https://open.feishu.cn/hook/x", view.Webhook)
+	assert.True(t, view.AgentAPIKeyConfigured)
+
+	require.NoError(t, svc.SaveWebhook(""))
+
+	view, err = svc.ReadSecretsView()
+	require.NoError(t, err)
+	assert.False(t, view.WebhookConfigured)
+	assert.True(t, view.AgentAPIKeyConfigured, "clearing one credential leaves the other in place")
+}
+
+func TestEffectiveAgentConfigCombinesFileSectionKeyAndHomeDir(t *testing.T) {
+	svc := newService(t)
+
+	require.NoError(t, svc.SaveAgentAPIKey(testAgentAPIKey))
+
+	resolved := svc.EffectiveAgentConfig(&inform.Config{Agent: &agent.Config{
+		BaseURL: testAgentBaseURL,
+		Model:   testAgentModel,
+	}})
+
+	assert.Equal(t, testAgentBaseURL, resolved.BaseURL)
+	assert.Equal(t, testAgentModel, resolved.Model)
+	assert.Equal(t, testAgentAPIKey, resolved.APIKey)
+	assert.Equal(t, svc.HomeDir(), resolved.WorkDir)
+
+	// the unfilled fields come back normalized, so a runner never has to defend
+	// itself against a half filled section.
+	assert.Equal(t, agent.DefaultProvider, resolved.Provider)
+	assert.Equal(t, agent.DefaultAllowedTools, resolved.AllowedTools)
+	assert.Equal(t, agent.DefaultTimeoutSeconds, resolved.TimeoutSeconds)
+}
+
+func TestEffectiveAgentConfigWithoutASection(t *testing.T) {
+	svc := newService(t)
+
+	resolved := svc.EffectiveAgentConfig(nil)
+
+	assert.Equal(t, agent.DefaultProvider, resolved.Provider)
+	assert.Empty(t, resolved.BaseURL)
+	assert.Empty(t, resolved.APIKey, "an installation without a stored key runs on the machine's own login")
+	assert.Equal(t, filepath.Clean(svc.HomeDir()), filepath.Clean(resolved.WorkDir))
+}

--- a/internal/service/fileconfig.go
+++ b/internal/service/fileconfig.go
@@ -20,6 +20,7 @@ package service
 import (
 	"fmt"
 
+	"github.com/vogo/informer/internal/agent"
 	"github.com/vogo/informer/internal/configstore"
 	"github.com/vogo/informer/internal/feed"
 )
@@ -66,6 +67,9 @@ type FileConfigView struct {
 
 	// Schedule is the editable schedule section, nil when the file defines none.
 	Schedule *Schedule `json:"schedule"`
+
+	// Agent is the editable agent section, nil when the file defines none.
+	Agent *agent.Config `json:"agent"`
 
 	// PreservedKeys lists the top level keys this build does not edit but keeps on
 	// save, so the page can state plainly that nothing else is dropped.
@@ -122,13 +126,42 @@ func (s *Service) ReadFileConfigView() (*FileConfigView, error) {
 		view.Schedule = &schedule
 	}
 
+	view.Agent, err = readAgentSection(doc)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, key := range doc.Keys() {
-		if key != feedSectionKey && key != scheduleSectionKey {
+		if key != feedSectionKey && key != scheduleSectionKey && key != agentSectionKey {
 			view.PreservedKeys = append(view.PreservedKeys, key)
 		}
 	}
 
 	return view, nil
+}
+
+// readAgentSection reads the agent section of one loaded document, nil when the
+// file defines none.
+func readAgentSection(doc *configstore.Doc) (*agent.Config, error) {
+	var section agentSection
+
+	found, err := doc.Unmarshal(agentSectionKey, &section)
+	if err != nil {
+		return nil, err
+	}
+
+	if !found {
+		return nil, nil //nolint:nilnil //"no section" is not an error, and the caller renders it as the defaults.
+	}
+
+	return &agent.Config{
+		Provider:       section.Provider,
+		BaseURL:        section.BaseURL,
+		Model:          section.Model,
+		AllowedTools:   section.AllowedTools,
+		TimeoutSeconds: section.TimeoutSeconds,
+		Command:        section.Command,
+	}, nil
 }
 
 // SaveFeedConfig validates and stores the feed section of informer.json.

--- a/internal/service/inform.go
+++ b/internal/service/inform.go
@@ -42,9 +42,10 @@ func (s *Service) TriggerInform(urlAddr string) (*inform.Result, error) {
 	}
 
 	result, err := inform.Run(&inform.Options{
-		HomeDir:    s.homeDir,
-		URLAddr:    s.ResolveWebhook(urlAddr),
-		FeedConfig: s.EffectiveFeedConfig(fileConfig),
+		HomeDir:     s.homeDir,
+		URLAddr:     s.ResolveWebhook(urlAddr),
+		FeedConfig:  s.EffectiveFeedConfig(fileConfig),
+		AgentConfig: s.EffectiveAgentConfig(fileConfig),
 	})
 	if err != nil {
 		return result, err

--- a/internal/service/preview.go
+++ b/internal/service/preview.go
@@ -20,7 +20,11 @@ package service
 import (
 	"fmt"
 
+	"github.com/vogo/logger"
+
+	"github.com/vogo/informer/internal/agent"
 	"github.com/vogo/informer/internal/feed"
+	"github.com/vogo/informer/internal/inform"
 )
 
 // Preview parses a stored source and returns its candidate articles.
@@ -41,18 +45,29 @@ func (s *Service) Preview(sourceID int64) ([]*feed.Article, error) {
 // PreviewSource parses an in memory source without persisting anything at all,
 // which lets a caller try out a source before it is stored.
 func (s *Service) PreviewSource(source *feed.Source) ([]*feed.Article, error) {
-	if source == nil {
-		return nil, fmt.Errorf("%w: source is nil", ErrInvalidArgument)
+	err := ValidateSource(source)
+	if err != nil {
+		return nil, err
 	}
 
-	if source.URL == "" && source.CURL == "" {
-		return nil, fmt.Errorf("%w: source has neither url nor curl", ErrInvalidArgument)
-	}
-
-	articles, err := feed.ParseArticles(source)
+	articles, err := feed.ParseArticles(source, s.agentConfig())
 	if err != nil {
 		return nil, fmt.Errorf("preview source %d: %w", source.ID, err)
 	}
 
 	return articles, nil
+}
+
+// agentConfig resolves the agent configuration a fetch outside of a full inform
+// run works with. A broken informer.json is not allowed to make a preview
+// impossible, so the defaults stand in for a section that cannot be read.
+func (s *Service) agentConfig() *agent.Config {
+	stored, err := s.ReadAgentConfig()
+	if err != nil {
+		logger.Warnf("read agent config failed, using defaults: %v", err)
+
+		stored = DefaultAgentConfig()
+	}
+
+	return s.EffectiveAgentConfig(&inform.Config{Agent: stored})
 }

--- a/internal/service/secrets.go
+++ b/internal/service/secrets.go
@@ -32,6 +32,11 @@ const (
 
 	// webhookKey is the top level key holding the bot webhook.
 	webhookKey = "webhook"
+
+	// agentAPIKeyKey is the top level key holding the agent api key. It shares
+	// the credential file with the webhook because both are things a data
+	// directory must not hand out when informer.json is shared.
+	agentAPIKeyKey = "agent_api_key" //nolint:gosec //document key name, not a credential.
 )
 
 // SecretsView is what the settings page learns about the credential file.
@@ -48,6 +53,11 @@ type SecretsView struct {
 	// Webhook is the stored bot address. It is a plain endpoint rather than a
 	// secret, so the settings page shows it in full.
 	Webhook string `json:"webhook"`
+
+	// AgentAPIKeyConfigured reports whether a non empty agent api key is stored.
+	// The key itself is never returned: unlike the webhook it is a real
+	// credential, and the page only needs to know that one is set.
+	AgentAPIKeyConfigured bool `json:"agent_api_key_configured"`
 }
 
 // SecretsFilePath is the credential file of the active data directory.
@@ -59,28 +69,42 @@ func (s *Service) SecretsFilePath() string {
 func (s *Service) ReadSecretsView() (*SecretsView, error) {
 	path := s.SecretsFilePath()
 
-	stored, err := s.readWebhook()
+	stored, err := s.readSecrets()
 	if err != nil {
 		return nil, err
 	}
 
 	return &SecretsView{
-		Path:              path,
-		Exists:            stored.exists,
-		WebhookConfigured: stored.webhook != "",
-		Webhook:           stored.webhook,
+		Path:                  path,
+		Exists:                stored.exists,
+		WebhookConfigured:     stored.webhook != "",
+		Webhook:               stored.webhook,
+		AgentAPIKeyConfigured: stored.agentAPIKey != "",
 	}, nil
 }
 
 // SaveWebhook stores the bot webhook in the credential file.
-//
-// An empty value clears the stored webhook rather than writing a blank one. The file
-// is written atomically and its permission is verified afterwards: if it cannot be
-// brought to 0600, the save fails and the previous file is left untouched, so a
-// credential is never left readable by other users of the machine.
+// An empty value clears the stored webhook rather than writing a blank one.
 func (s *Service) SaveWebhook(webhook string) error {
+	return s.saveSecret(webhookKey, webhook)
+}
+
+// SaveAgentAPIKey stores the agent api key in the credential file.
+// An empty value clears it, which is how an installation goes back to running the
+// agent with the credentials its own command line is already logged in with.
+func (s *Service) SaveAgentAPIKey(apiKey string) error {
+	return s.saveSecret(agentAPIKeyKey, apiKey)
+}
+
+// saveSecret replaces one key of the credential file.
+//
+// The whole document is re-read inside the write lock so a second credential saved
+// at the same time is not lost, and the result is written atomically at 0600: if the
+// permission cannot be enforced the save fails and the previous file stays in place,
+// so a credential is never left readable by other users of the machine.
+func (s *Service) saveSecret(key, value string) error {
 	path := s.SecretsFilePath()
-	value := strings.TrimSpace(webhook)
+	trimmed := strings.TrimSpace(value)
 
 	return configstore.WithLock(path, configstore.DefaultLockTimeout, func() error {
 		doc, err := configstore.Load(path)
@@ -88,7 +112,7 @@ func (s *Service) SaveWebhook(webhook string) error {
 			return err
 		}
 
-		err = doc.Set(webhookKey, value)
+		err = doc.Set(key, trimmed)
 		if err != nil {
 			return err
 		}
@@ -112,7 +136,7 @@ func (s *Service) ResolveWebhook(argAddr string) string {
 		return trimmed
 	}
 
-	stored, err := s.readWebhook()
+	stored, err := s.readSecrets()
 	if err != nil {
 		// a broken credential file must not abort the daily run: the report is still
 		// generated and stored, it is only not delivered.
@@ -122,25 +146,48 @@ func (s *Service) ResolveWebhook(argAddr string) string {
 	return stored.webhook
 }
 
-// storedSecrets is the credential file state one read resolved.
-type storedSecrets struct {
-	webhook string
-	exists  bool
+// readAgentAPIKey returns the stored agent api key, empty when none is configured.
+func (s *Service) readAgentAPIKey() (string, error) {
+	stored, err := s.readSecrets()
+	if err != nil {
+		return "", err
+	}
+
+	return stored.agentAPIKey, nil
 }
 
-// readWebhook reads the stored webhook and whether the credential file exists.
-func (s *Service) readWebhook() (storedSecrets, error) {
+// storedSecrets is the credential file state one read resolved.
+type storedSecrets struct {
+	webhook     string
+	agentAPIKey string
+	exists      bool
+}
+
+// readSecrets reads every stored credential and whether the file exists.
+func (s *Service) readSecrets() (storedSecrets, error) {
 	doc, err := configstore.Load(s.SecretsFilePath())
 	if err != nil {
 		return storedSecrets{}, err
 	}
 
+	stored := storedSecrets{exists: doc.Exists()}
+
 	var webhook string
 
 	_, err = doc.Unmarshal(webhookKey, &webhook)
 	if err != nil {
-		return storedSecrets{exists: doc.Exists()}, err
+		return stored, err
 	}
 
-	return storedSecrets{webhook: strings.TrimSpace(webhook), exists: doc.Exists()}, nil
+	var apiKey string
+
+	_, err = doc.Unmarshal(agentAPIKeyKey, &apiKey)
+	if err != nil {
+		return stored, err
+	}
+
+	stored.webhook = strings.TrimSpace(webhook)
+	stored.agentAPIKey = strings.TrimSpace(apiKey)
+
+	return stored, nil
 }

--- a/internal/service/source.go
+++ b/internal/service/source.go
@@ -19,9 +19,11 @@ package service
 
 import (
 	"fmt"
+	"strings"
 
 	"gorm.io/gorm"
 
+	"github.com/vogo/informer/internal/agent"
 	"github.com/vogo/informer/internal/feed"
 )
 
@@ -65,6 +67,41 @@ type SourceQuery struct {
 	FetchStatus string `json:"fetch_status"`
 }
 
+// ValidateSource refuses a source its resolved parser could not act on.
+//
+// What "unusable" means depends on the parse type: a fetching source needs an
+// address, while an agent source needs an instruction and no address at all. Both
+// rules live here so that creating, updating and previewing a source agree on what
+// a usable source is.
+//
+// The stored parse type is resolved, not judged: a value written by a build this
+// one does not know about keeps falling back to the historical derivation, exactly
+// as a fetch does. Refusing an unknown name is the job of the two write paths.
+func ValidateSource(source *feed.Source) error {
+	if source == nil {
+		return fmt.Errorf("%w: source is nil", ErrInvalidArgument)
+	}
+
+	if source.ResolveParseType() != feed.ParseTypeAgent {
+		if source.URL == "" && source.CURL == "" {
+			return fmt.Errorf("%w: source has neither url nor curl", ErrInvalidArgument)
+		}
+
+		return nil
+	}
+
+	if strings.TrimSpace(source.AgentPrompt) == "" {
+		return fmt.Errorf("%w: agent source has no prompt", ErrInvalidArgument)
+	}
+
+	provider := strings.TrimSpace(source.AgentProvider)
+	if provider != "" && !agent.IsLegalProvider(provider) {
+		return fmt.Errorf("%w: unknown agent provider %q", ErrInvalidArgument, provider)
+	}
+
+	return nil
+}
+
 // CreateSource stores a new source. A source is enabled by default and belongs to
 // the default category unless the caller says otherwise.
 func (s *Service) CreateSource(source *feed.Source) error {
@@ -72,12 +109,19 @@ func (s *Service) CreateSource(source *feed.Source) error {
 		return fmt.Errorf("%w: source is nil", ErrInvalidArgument)
 	}
 
-	if source.URL == "" {
-		return fmt.Errorf("%w: source url is empty", ErrInvalidArgument)
-	}
-
 	if source.ParseType != "" && !feed.IsLegalParseType(source.ParseType) {
 		return fmt.Errorf("%w: unknown parse type %q", ErrInvalidArgument, source.ParseType)
+	}
+
+	err := ValidateSource(source)
+	if err != nil {
+		return err
+	}
+
+	// a fetching source is created from its url alone, the shape every existing
+	// caller uses; only an agent source is allowed to carry no address.
+	if source.URL == "" && source.ResolveParseType() != feed.ParseTypeAgent {
+		return fmt.Errorf("%w: source url is empty", ErrInvalidArgument)
 	}
 
 	if source.CategoryID == 0 {
@@ -117,6 +161,11 @@ func (s *Service) UpdateSource(source *feed.Source) error {
 
 	if source.ParseType != "" && !feed.IsLegalParseType(source.ParseType) {
 		return fmt.Errorf("%w: unknown parse type %q", ErrInvalidArgument, source.ParseType)
+	}
+
+	err := ValidateSource(source)
+	if err != nil {
+		return err
 	}
 
 	if source.CategoryID == 0 {

--- a/internal/service/source_filter_test.go
+++ b/internal/service/source_filter_test.go
@@ -203,7 +203,7 @@ func TestSourceQueryRejectsUnknownFilterValues(t *testing.T) {
 
 	// an unknown enum is a mistake worth reporting, never an alias of "all".
 	const (
-		absentParseType   = "agent"
+		absentParseType   = "rss-v9"
 		absentFetchStatus = "half-broken"
 	)
 
@@ -292,7 +292,8 @@ func TestLegalParseTypesIsTheFilterVocabulary(t *testing.T) {
 	svc := newService(t)
 
 	types := feed.LegalParseTypes()
-	assert.Equal(t, []string{feed.ParseTypeFeed, feed.ParseTypeRegex, feed.ParseTypeJSON}, types)
+	assert.Equal(t,
+		[]string{feed.ParseTypeFeed, feed.ParseTypeRegex, feed.ParseTypeJSON, feed.ParseTypeAgent}, types)
 
 	// every offered type is a value the query accepts, so the sidebar can build
 	// its options from this set alone.


### PR DESCRIPTION
## 做了什么

订阅源在 `feed` / `regex` / `json` 之外新增 **`agent`** 解析类型：用户只写一段自然语言任务，
informer 自动在提示词末尾追加 JSON 输出契约，再把 Agent 的答复解析成文章列表。

```bash
./informer feed agent "Go 语言周报" "搜索 Go 语言最近的技术文章与发布公告，挑出最值得阅读的几篇，给出标题和链接。"
./informer feed parse 1
```

## 主要改动

- **`internal/agent`（新包）**：`Config` / `Run` / `BuildPrompt` / `ParseItems`，以及 claude 命令行 runner。
  支持配置 `base_url`、api key、`model`、可用工具与超时；`codex` 已在配置层预留，运行时明确报
  「本版本未实现」，而不是静默换成另一个 Agent。
- **输出解析容错**：代码块包裹、裸数组、答复前后的闲聊都能读出来；标题为空、非绝对 http 链接、
  重复链接一律丢弃，Agent 编造格式时不会污染文章库。
- **`feed.Source`** 新增 `agent_provider` / `agent_prompt` 两列。agent 源不需要 `url`，但没有提示词
  会被拒绝保存。历史推导（`is_json` / `regex`）永远不可能得出 `agent`，旧库不受影响。
- **配置**：`informer.json` 新增 `agent` 节（端点、模型、工具、超时、可执行文件）；api key 与机器人
  地址同放在 0600 的 `informer.secret.json`。两者都留空时直接运行 `claude`，用本机自身已登录的凭据——
  本机 `claude` 能跑，agent 订阅就能跑。
- **命令行**：新增 `informer feed agent <标题> <提示词>`，`feed view` 输出 agent 字段。
- **桌面端**：订阅表单新增 agent 分支（Agent 选择 + 提示词），设置页新增「Agent 配置」卡片
  （含独立保存的 API Key）。

## 验证

- `go test ./...`（根模块与 `cmd/informer-ui`）全绿；`golangci-lint run --new-from-rev=master` 两个模块均 0 issue；
  license header 检查通过；前端 `vue-tsc --noEmit` 与 `npm run build` 通过。
- **端到端实跑**（真实调用本机 `claude` 2.1.226）：
  - `informer feed parse` 取回 3 篇文章（遵守 `max_fetch_num`）；
  - 完整 `informer` 运行把文章写入文章库并生成当日日报 Markdown，订阅抓取状态为正常；
  - Agent 可执行文件缺失与运行超时都被记入订阅的 `status` / `error_info`，不会拖住整轮抓取。

🤖 Generated with [Claude Code](https://claude.com/claude-code)