### PR TITLE
feat(agent): auto-locate and remember claude/codex path

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,13 +263,15 @@ Agent 的接口地址、密钥与模型是全局配置，写在 `informer.json` 
 | `model` | 使用的模型 | 留空表示沿用 Agent 的默认模型 |
 | `allowed_tools` | 允许 Agent 使用的工具，逗号分隔 | 留空使用默认 `WebSearch,WebFetch` |
 | `timeout_seconds` | 单次运行超时 | 填 0 表示使用默认 300 秒，合法范围 10 ~ 3600 |
-| `command` | Agent 可执行文件 | 留空表示用 `PATH` 里的 `claude` |
+| `command` | Agent 可执行文件 | 留空时会在 PATH、常见安装目录与登录 Shell 中自动查找 `claude`/`codex`，找到后写入配置；也可在设置页手动填写或点「自动查找」 |
 
 API Key 不写进 `informer.json`，而是放在同目录的 `informer.secret.json` 的 `agent_api_key` 字段里。
-`base_url` 与 `agent_api_key` 都留空时，informer 直接运行 `claude`，用的就是本机 `claude` 自身已登录的凭据——
-也就是说，只要本机 `claude` 能跑，agent 订阅就能跑，不需要额外配置。
+`base_url` 与 `agent_api_key` 都留空时，informer 直接运行本机 Agent，用的就是该 Agent 自身已登录的凭据——
+也就是说，只要本机 `claude`（或对应 Agent）能跑，agent 订阅就能跑，不需要额外配置。
 
-前置条件：本机已安装 Claude Code 命令行（`claude --version` 能正常输出）。
+桌面版从 Dock / Finder 启动时往往没有终端里的 PATH。`command` 留空时，informer 会在 PATH、Homebrew / npm / nvm 等常见目录以及登录 Shell 里查找可执行文件，并把绝对路径写回 `informer.json`；设置页也可以手动填写或点「自动查找」。
+
+前置条件：本机已安装对应命令行 Agent（例如 `claude --version` 能正常输出）。
 
 ## 六、桌面版 informer-ui
 

--- a/cmd/informer-ui/binding_settings.go
+++ b/cmd/informer-ui/binding_settings.go
@@ -307,6 +307,18 @@ func (a *App) SaveAgentAPIKey(apiKey string) error {
 	return a.svc.SaveAgentAPIKey(apiKey)
 }
 
+// DetectAgentCommand locates the default executable of the given agent provider on
+// this machine. The path is returned for the settings page to fill in; it is not
+// written until the user saves, or until an agent run remembers an empty command.
+func (a *App) DetectAgentCommand(provider string) (string, error) {
+	err := a.ready()
+	if err != nil {
+		return "", err
+	}
+
+	return a.svc.DetectAgentCommand(provider)
+}
+
 func toAgentConfigDTO(config *agent.Config) *AgentConfigDTO {
 	return &AgentConfigDTO{
 		Provider:       config.Provider,

--- a/cmd/informer-ui/frontend/src/SettingsPanel.vue
+++ b/cmd/informer-ui/frontend/src/SettingsPanel.vue
@@ -22,6 +22,7 @@ import {
   useMessage
 } from 'naive-ui'
 import {
+  DetectAgentCommand,
   ReadConfig,
   ReadSecrets,
   RebuildHistoryIndex,
@@ -67,6 +68,7 @@ const agent = reactive({
 })
 const agentProviderOptions = ref<{label: string; value: string}[]>([])
 const agentSaving = ref(false)
+const agentDetecting = ref(false)
 const agentAPIKeyConfigured = ref(false)
 const agentAPIKeyInput = ref('')
 const agentAPIKeySaving = ref(false)
@@ -187,6 +189,23 @@ async function saveAgent() {
   }
 }
 
+async function detectAgentCommand() {
+  agentDetecting.value = true
+  try {
+    const path = await DetectAgentCommand(agent.provider)
+    if (!path) {
+      message.warning('未找到可执行文件')
+      return
+    }
+    agent.command = path
+    message.success('已找到可执行文件，请保存 Agent 配置')
+  } catch (e) {
+    message.error(`查找失败：${errorText(e)}`)
+  } finally {
+    agentDetecting.value = false
+  }
+}
+
 async function saveAgentAPIKey() {
   agentAPIKeySaving.value = true
   try {
@@ -299,10 +318,20 @@ async function rebuild() {
             <n-input-number v-model:value="agent.timeoutSeconds" :min="0" :max="3600" style="width: 100%" />
           </n-form-item>
           <n-form-item label="可执行文件">
-            <n-input v-model:value="agent.command" placeholder="留空使用 PATH 中的 claude" />
+            <n-space :size="8" style="width: 100%">
+              <n-input
+                v-model:value="agent.command"
+                placeholder="留空则运行时自动查找并记住；例如 /opt/homebrew/bin/claude"
+                style="flex: 1; min-width: 0"
+              />
+              <n-button :loading="agentDetecting" @click="detectAgentCommand">自动查找</n-button>
+            </n-space>
           </n-form-item>
         </n-form>
-        <n-text depth="3" style="font-size: 12px">「超时」填 0 表示使用默认窗口（300 秒）。</n-text>
+        <n-text depth="3" style="font-size: 12px">
+          「超时」填 0 表示使用默认窗口（300 秒）。可执行文件留空时，抓取会在 PATH、常见安装目录和登录 Shell 中查找
+          claude / codex，找到后写入配置。
+        </n-text>
 
         <n-descriptions :column="1" size="small" style="margin: 12px 0">
           <n-descriptions-item label="API Key">

--- a/cmd/informer-ui/frontend/src/bindings.ts
+++ b/cmd/informer-ui/frontend/src/bindings.ts
@@ -9,6 +9,7 @@ export {
   DailyIndex,
   DeleteCategory,
   DeleteSource,
+  DetectAgentCommand,
   HomeDir,
   ListArticles,
   ListCategories,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -111,8 +111,9 @@ type Config struct {
 	// TimeoutSeconds bounds one run; the run is killed when it is exceeded.
 	TimeoutSeconds int `json:"timeout_seconds"`
 
-	// Command overrides the executable name, for a machine where the agent is
-	// installed under a different path. An empty value uses the provider default.
+	// Command overrides the executable path. An empty value is resolved to the
+	// provider default by searching PATH, common install directories and the
+	// user's login shell, then remembered in informer.json on the first hit.
 	Command string `json:"command"`
 
 	// WorkDir is the directory the agent process runs in. It is set by the

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -52,9 +52,9 @@ type claudeEnvelope struct {
 
 // runClaude executes one non interactive Claude Code run and returns its answer text.
 func runClaude(ctx context.Context, cfg *Config, prompt string) (string, error) {
-	command := cfg.Command
-	if command == "" {
-		command = ClaudeCommand
+	command, err := ResolveCommand(cfg.Provider, cfg.Command)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrAgentFailed, err)
 	}
 
 	cmd := exec.CommandContext(ctx, command, claudeArgs(cfg, prompt)...)
@@ -67,7 +67,7 @@ func runClaude(ctx context.Context, cfg *Config, prompt string) (string, error) 
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		// the timeout is the common failure of a browsing agent, and the raw
 		// exec message does not say so; name it where the source error is stored.

--- a/internal/agent/locate.go
+++ b/internal/agent/locate.go
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// CodexCommand is the default executable of the Codex command line.
+const CodexCommand = "codex"
+
+// ErrCommandNotFound marks a locate that found no usable agent binary.
+var ErrCommandNotFound = errors.New("agent command not found")
+
+// loginShellLocateTimeout bounds how long a login-shell PATH probe may take.
+// Desktop apps often inherit a stripped PATH; asking the user's shell is reliable
+// but must not stall a fetch when the shell init is slow.
+const loginShellLocateTimeout = 3 * time.Second
+
+// DefaultCommandName is the bare executable name of a provider when none is configured.
+func DefaultCommandName(provider string) string {
+	if strings.TrimSpace(provider) == ProviderCodex {
+		return CodexCommand
+	}
+
+	return ClaudeCommand
+}
+
+// ResolveCommand turns a configured command into an absolute executable path.
+//
+// An empty command looks up the provider default. A bare name is searched on PATH
+// and in common install locations. An absolute or relative path is verified as an
+// executable file. The returned path is always absolute when the lookup succeeds.
+func ResolveCommand(provider, command string) (string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return LocateCommand(provider)
+	}
+
+	if filepath.IsAbs(command) || strings.ContainsRune(command, filepath.Separator) ||
+		(runtime.GOOS == "windows" && strings.Contains(command, `/`)) {
+		return requireExecutable(command)
+	}
+
+	return lookUp(command)
+}
+
+// LocateCommand finds the default executable of a provider on this machine.
+func LocateCommand(provider string) (string, error) {
+	return lookUp(DefaultCommandName(provider))
+}
+
+func lookUp(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" || !isSafeCommandName(name) {
+		return "", fmt.Errorf("%w: empty or invalid command name", ErrCommandNotFound)
+	}
+
+	if path, err := exec.LookPath(name); err == nil {
+		return absExecutable(path)
+	}
+
+	for _, dir := range candidateDirs() {
+		candidate := filepath.Join(dir, name)
+		if path, err := requireExecutable(candidate); err == nil {
+			return path, nil
+		}
+
+		if runtime.GOOS == "windows" {
+			if path, err := requireExecutable(candidate + ".exe"); err == nil {
+				return path, nil
+			}
+		}
+	}
+
+	if path, err := lookUpViaLoginShell(name); err == nil {
+		return path, nil
+	}
+
+	return "", fmt.Errorf("%w: %q not found in PATH or common install locations", ErrCommandNotFound, name)
+}
+
+func lookUpViaLoginShell(name string) (string, error) {
+	if runtime.GOOS == "windows" {
+		return "", ErrCommandNotFound
+	}
+
+	shell := strings.TrimSpace(os.Getenv("SHELL"))
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), loginShellLocateTimeout)
+	defer cancel()
+
+	// name is restricted to a safe command token, so interpolating it into the
+	// shell snippet cannot turn into an arbitrary command.
+	cmd := exec.CommandContext(ctx, shell, "-lc", "command -v "+name)
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", ErrCommandNotFound
+	}
+
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		return "", ErrCommandNotFound
+	}
+
+	return requireExecutable(path)
+}
+
+func requireExecutable(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("%w: empty path", ErrCommandNotFound)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s: %w", ErrCommandNotFound, path, err)
+	}
+
+	if info.IsDir() {
+		return "", fmt.Errorf("%w: %s is a directory", ErrCommandNotFound, path)
+	}
+
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+		return "", fmt.Errorf("%w: %s is not executable", ErrCommandNotFound, path)
+	}
+
+	return absExecutable(path)
+}
+
+func absExecutable(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s: %w", ErrCommandNotFound, path, err)
+	}
+
+	return abs, nil
+}
+
+// isSafeCommandName reports whether name is a bare executable token safe to pass
+// to a login shell. Paths and shell metacharacters are refused.
+func isSafeCommandName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+
+	for _, r := range name {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+
+		return false
+	}
+
+	return true
+}
+
+func candidateDirs() []string {
+	dirs := make([]string, 0, 24)
+
+	switch runtime.GOOS {
+	case "darwin":
+		dirs = append(dirs, "/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin")
+	case "linux":
+		dirs = append(dirs, "/usr/local/bin", "/usr/bin", "/snap/bin")
+	case "windows":
+		if local := os.Getenv("LOCALAPPDATA"); local != "" {
+			dirs = append(dirs,
+				filepath.Join(local, "Programs"),
+				filepath.Join(local, "Yarn", "bin"),
+				filepath.Join(local, "fnm_multishells"),
+			)
+		}
+
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			dirs = append(dirs,
+				filepath.Join(appData, "npm"),
+				filepath.Join(appData, "nvm"),
+			)
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return uniqueExistingDirs(dirs)
+	}
+
+	dirs = append(dirs,
+		filepath.Join(home, ".local", "bin"),
+		filepath.Join(home, "bin"),
+		filepath.Join(home, ".npm-global", "bin"),
+		filepath.Join(home, ".yarn", "bin"),
+		filepath.Join(home, ".bun", "bin"),
+		filepath.Join(home, ".volta", "bin"),
+		filepath.Join(home, ".asdf", "shims"),
+		filepath.Join(home, ".local", "share", "fnm", "aliases", "default", "bin"),
+	)
+
+	dirs = append(dirs, versionManagerBinDirs(filepath.Join(home, ".nvm", "versions", "node"))...)
+	dirs = append(dirs, versionManagerBinDirs(filepath.Join(home, ".fnm", "node-versions"))...)
+	dirs = append(dirs, versionManagerBinDirs(filepath.Join(home, ".local", "share", "fnm", "node-versions"))...)
+
+	return uniqueExistingDirs(dirs)
+}
+
+// versionManagerBinDirs lists <root>/<version>/bin directories under a node version
+// manager install tree. Missing roots are ignored.
+func versionManagerBinDirs(root string) []string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+
+	dirs := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		dirs = append(dirs, filepath.Join(root, entry.Name(), "bin"))
+		// fnm stores binaries under installation/bin rather than bin.
+		dirs = append(dirs, filepath.Join(root, entry.Name(), "installation", "bin"))
+	}
+
+	return dirs
+}
+
+func uniqueExistingDirs(dirs []string) []string {
+	seen := make(map[string]struct{}, len(dirs))
+	out := make([]string, 0, len(dirs))
+
+	for _, dir := range dirs {
+		dir = filepath.Clean(dir)
+		if dir == "" || dir == "." {
+			continue
+		}
+
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+
+		seen[dir] = struct{}{}
+		out = append(out, dir)
+	}
+
+	return out
+}

--- a/internal/agent/locate_test.go
+++ b/internal/agent/locate_test.go
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vogo/informer/internal/agent"
+)
+
+func TestDefaultCommandName(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, agent.ClaudeCommand, agent.DefaultCommandName(agent.ProviderClaude))
+	assert.Equal(t, agent.ClaudeCommand, agent.DefaultCommandName(""))
+	assert.Equal(t, agent.CodexCommand, agent.DefaultCommandName(agent.ProviderCodex))
+}
+
+func TestResolveCommandUsesAnAbsoluteExecutable(t *testing.T) {
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("the fixture is a posix shell script")
+	}
+
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "my-claude")
+	require.NoError(t, os.WriteFile(binary, []byte("#!/bin/sh\n"), 0o700)) //nolint:gosec //test helper binary.
+
+	resolved, err := agent.ResolveCommand(agent.ProviderClaude, binary)
+	require.NoError(t, err)
+	assert.Equal(t, binary, resolved)
+}
+
+func TestResolveCommandFindsABareNameOnPATH(t *testing.T) {
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("the fixture is a posix shell script")
+	}
+
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "path-claude")
+	require.NoError(t, os.WriteFile(binary, []byte("#!/bin/sh\n"), 0o700)) //nolint:gosec //test helper binary.
+
+	t.Setenv("PATH", dir)
+
+	resolved, err := agent.ResolveCommand(agent.ProviderClaude, "path-claude")
+	require.NoError(t, err)
+	assert.Equal(t, binary, resolved)
+}
+
+func TestResolveCommandFindsABareNameInACommonDir(t *testing.T) {
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("the fixture is a posix shell script")
+	}
+
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".local", "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o700))
+
+	// a unique name avoids matching a real install under /opt/homebrew/bin.
+	name := "informer-locate-test"
+	binary := filepath.Join(binDir, name)
+	require.NoError(t, os.WriteFile(binary, []byte("#!/bin/sh\n"), 0o700)) //nolint:gosec //test helper binary.
+
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "/usr/bin")
+
+	resolved, err := agent.ResolveCommand(agent.ProviderClaude, name)
+	require.NoError(t, err)
+	assert.Equal(t, binary, resolved)
+}
+
+func TestResolveCommandRejectsAMissingPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := agent.ResolveCommand(agent.ProviderClaude, filepath.Join(t.TempDir(), "missing"))
+	require.ErrorIs(t, err, agent.ErrCommandNotFound)
+}

--- a/internal/service/agentconfig.go
+++ b/internal/service/agentconfig.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/vogo/logger"
+
 	"github.com/vogo/informer/internal/agent"
 	"github.com/vogo/informer/internal/configstore"
 	"github.com/vogo/informer/internal/inform"
@@ -128,6 +130,10 @@ func ValidateAgentConfig(config *agent.Config) error {
 // The file section decides the endpoint and model, the credential file supplies the
 // api key, and the data directory becomes the working directory of the agent process
 // so it never inherits whatever directory the caller happened to start in.
+//
+// When the file leaves command empty, the provider default is located on this machine
+// and the absolute path is remembered in informer.json, so a desktop app that started
+// without the user's shell PATH only has to discover the binary once.
 func (s *Service) EffectiveAgentConfig(fileConfig *inform.Config) *agent.Config {
 	config := DefaultAgentConfig()
 
@@ -143,5 +149,74 @@ func (s *Service) EffectiveAgentConfig(fileConfig *inform.Config) *agent.Config 
 		resolved.APIKey = key
 	}
 
+	s.ensureAgentCommand(resolved)
+
 	return resolved
+}
+
+// DetectAgentCommand locates the default executable of a provider on this machine.
+// It does not write the path: the settings page fills the field and the user saves,
+// or the next agent run remembers it through EffectiveAgentConfig.
+func (s *Service) DetectAgentCommand(provider string) (string, error) {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		provider = agent.DefaultProvider
+	}
+
+	if !agent.IsLegalProvider(provider) {
+		return "", fmt.Errorf("%w: unknown agent provider %q", ErrInvalidArgument, provider)
+	}
+
+	return agent.LocateCommand(provider)
+}
+
+// ensureAgentCommand fills cfg.Command with an absolute executable path when possible.
+// A previously empty command is persisted so the next run skips the search.
+func (s *Service) ensureAgentCommand(cfg *agent.Config) {
+	if cfg == nil {
+		return
+	}
+
+	configured := strings.TrimSpace(cfg.Command)
+
+	path, err := agent.ResolveCommand(cfg.Provider, configured)
+	if err != nil {
+		return
+	}
+
+	cfg.Command = path
+
+	if configured != "" {
+		return
+	}
+
+	s.rememberAgentCommand(path)
+}
+
+// rememberAgentCommand stores a discovered executable path when the file still has
+// none. Failures are logged rather than returned: discovering the path for this run
+// already succeeded, and a later run can try again.
+func (s *Service) rememberAgentCommand(command string) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return
+	}
+
+	stored, err := s.ReadAgentConfig()
+	if err != nil {
+		logger.Warnf("remember agent command: read config: %v", err)
+
+		return
+	}
+
+	if strings.TrimSpace(stored.Command) != "" {
+		return
+	}
+
+	stored.Command = command
+
+	err = s.SaveAgentConfig(stored)
+	if err != nil {
+		logger.Warnf("remember agent command: save config: %v", err)
+	}
 }

--- a/internal/service/agentconfig_test.go
+++ b/internal/service/agentconfig_test.go
@@ -182,3 +182,77 @@ func TestEffectiveAgentConfigWithoutASection(t *testing.T) {
 	assert.Empty(t, resolved.APIKey, "an installation without a stored key runs on the machine's own login")
 	assert.Equal(t, filepath.Clean(svc.HomeDir()), filepath.Clean(resolved.WorkDir))
 }
+
+func TestEffectiveAgentConfigRemembersADiscoveredCommand(t *testing.T) {
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("the fixture is a posix shell script")
+	}
+
+	svc := newService(t)
+
+	path, err := agent.LocateCommand(agent.ProviderClaude)
+	if err != nil {
+		dir := t.TempDir()
+		path = filepath.Join(dir, agent.ClaudeCommand)
+		require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), 0o700)) //nolint:gosec //test helper binary.
+		t.Setenv("PATH", dir)
+
+		path, err = agent.LocateCommand(agent.ProviderClaude)
+		require.NoError(t, err)
+	}
+
+	resolved := svc.EffectiveAgentConfig(nil)
+	assert.Equal(t, path, resolved.Command)
+
+	stored, err := svc.ReadAgentConfig()
+	require.NoError(t, err)
+	assert.Equal(t, path, stored.Command, "the discovered path is written back for the next run")
+}
+
+func TestEffectiveAgentConfigKeepsAnExplicitCommand(t *testing.T) {
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("the fixture is a posix shell script")
+	}
+
+	svc := newService(t)
+
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "custom-claude")
+	require.NoError(t, os.WriteFile(binary, []byte("#!/bin/sh\n"), 0o700)) //nolint:gosec //test helper binary.
+	require.NoError(t, svc.SaveAgentConfig(&agent.Config{Command: binary}))
+
+	other := filepath.Join(dir, agent.ClaudeCommand)
+	require.NoError(t, os.WriteFile(other, []byte("#!/bin/sh\n"), 0o700)) //nolint:gosec //test helper binary.
+	t.Setenv("PATH", dir)
+
+	resolved := svc.EffectiveAgentConfig(&inform.Config{Agent: &agent.Config{Command: binary}})
+	assert.Equal(t, binary, resolved.Command)
+
+	stored, err := svc.ReadAgentConfig()
+	require.NoError(t, err)
+	assert.Equal(t, binary, stored.Command, "an explicit command is never replaced by auto-detect")
+}
+
+func TestDetectAgentCommand(t *testing.T) {
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("the fixture is a posix shell script")
+	}
+
+	svc := newService(t)
+
+	dir := t.TempDir()
+	binary := filepath.Join(dir, agent.ClaudeCommand)
+	require.NoError(t, os.WriteFile(binary, []byte("#!/bin/sh\n"), 0o700)) //nolint:gosec //test helper binary.
+	t.Setenv("PATH", dir)
+
+	path, err := svc.DetectAgentCommand(agent.ProviderClaude)
+	require.NoError(t, err)
+	assert.Equal(t, binary, path)
+
+	stored, err := svc.ReadAgentConfig()
+	require.NoError(t, err)
+	assert.Empty(t, stored.Command, "detect only reports the path; saving is left to the caller")
+
+	_, err = svc.DetectAgentCommand(unknownAgentName)
+	require.ErrorIs(t, err, service.ErrInvalidArgument)
+}


### PR DESCRIPTION
## Summary
- Auto-discover `claude`/`codex` from PATH, common install locations, and the login shell when `command` is empty
- Remember the absolute path in `informer.json` so Dock/Finder launches do not need rediscovery
- Settings page keeps manual path config and adds an 「自动查找」 button

## Test plan
- [ ] Leave agent `command` empty, run an agent source / preview, confirm path is written to `informer.json`
- [ ] Open Settings → Agent → 自动查找, confirm path fills and save persists it
- [ ] Set a custom absolute path, confirm auto-detect does not overwrite it
- [ ] `go test ./internal/agent/ ./internal/service/`


Made with [Cursor](https://cursor.com)