### PR TITLE
feat(config): store bot webhook in informer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ EOF
 - 钉钉：`https://oapi.dingtalk.com/robot/send?access_token=xxxxx`
 - 飞书：`https://open.feishu.cn/open-apis/bot/v2/hook/xxxxxxxxx`
 
-地址可以在命令行显式传入，也可以保存到[敏感配置文件](#敏感配置文件-informersecretjson)后不带参数运行。
+地址可以在命令行显式传入，也可以保存到 `informer.json` 的顶层 `webhook` 字段后不带参数运行。
 
 ### 5. 执行一次推送
 
@@ -74,7 +74,7 @@ EOF
 ./informer "https://oapi.dingtalk.com/robot/send?access_token=xxxxx"
 ```
 
-命令行传入的地址优先；不传时使用 `informer.secret.json` 里保存的 webhook。两处都没有地址时，
+命令行传入的地址优先；不传时使用 `informer.json` 里保存的 webhook。两处都没有地址时，
 只生成内容并写入日报文件，不推送。
 
 ### 6. 配置定时任务
@@ -85,7 +85,7 @@ crontab 不会加载 shell 的 profile，需要在命令里显式写环境变量
 00 10 * * * INFORMER_HOME=/root/.informer /root/informer/informer "https://oapi.dingtalk.com/robot/send?access_token=xxxxx" >> /root/informer/cron.log 2>&1
 ```
 
-飞书同理，把地址换成飞书的 webhook 即可。地址已保存在 `informer.secret.json` 时可以省略参数：
+飞书同理，把地址换成飞书的 webhook 即可。地址已保存在 `informer.json` 时可以省略参数：
 
 ```
 00 10 * * * INFORMER_HOME=/root/.informer /root/informer/informer >> /root/informer/cron.log 2>&1
@@ -128,6 +128,12 @@ informer 不会自动同步多个数据主目录，也不支持同时使用多�
 
 除 `feed` 节外还有一个顶层节 `agent`，供 `agent` 类型的订阅使用，详见[「agent 解析订阅」](#agent-解析订阅)。
 
+还有一个顶层字段 `webhook`，存放钉钉 / 飞书机器人地址（不是敏感凭证）：
+
+| 配置项 | 含义 | 取值 |
+| --- | --- | --- |
+| `webhook` | 推送用的机器人 webhook | URL 字符串；留空或不写表示不推送 |
+
 还有一个顶层节 `schedule`，只被桌面版「定时任务」读取，命令行与系统 crontab 会忽略它（命令行的定时推送仍由 crontab 负责）：
 
 | 配置项 | 含义 | 取值 |
@@ -139,27 +145,25 @@ informer 不会自动同步多个数据主目录，也不支持同时使用多�
 
 无论是命令行手写还是桌面版「设置」页保存，写入都遵守下面几条约定：
 
-- **保留未知字段**：保存只替换 `feed`、`agent` 与 `schedule` 三节，文件里其它顶层字段（包括这个版本还不认识的字段）连同顺序一起原样保留。
+- **保留未知字段**：保存只替换 `feed`、`agent`、`schedule` 与 `webhook`，文件里其它顶层字段（包括这个版本还不认识的字段）连同顺序一起原样保留。
 - **原子替换**：先写同目录下的临时文件再 `rename` 覆盖，所以并发运行的 crontab 读到的要么是旧文件、要么是新文件，不会读到写了一半的内容。
 - **跨进程写锁**：写入前会创建 `informer.json.lock`，两个「读—改—写」不会互相覆盖造成丢失更新。锁有等待上限，
   等不到会直接报错而不是一直卡住；进程被杀留下的陈旧锁会在明显过期后被自动接管。
 
 ### 敏感配置文件 informer.secret.json
 
-机器人地址（webhook）不写进 `informer.json`，而是单独存放在数据主目录下的 `informer.secret.json`：
+Agent API Key 不写进 `informer.json`，而是单独存放在数据主目录下的 `informer.secret.json`：
 
 ```json
 {
-  "webhook": "https://oapi.dingtalk.com/robot/send?access_token=xxxxx",
   "agent_api_key": "sk-xxxxx"
 }
 ```
 
 - 该文件无论新建还是改写，权限都会被设置并校验为 **0600**；权限无法落实时保存直接失败，不会以不安全的状态写下去
   （Windows 不支持 Unix 权限位，这一步在 Windows 上无法校验）。
-- 桌面版「设置」页只显示「是否已配置」和一段打码后的前缀，完整地址不会回传到界面。
-- 命令行显式传入的地址**优先**；不传地址时才使用这个文件里保存的 webhook。
-- `agent_api_key` 是 `agent` 类型订阅调用 AI Agent 时使用的密钥，同样只存在这个文件里；桌面版只显示「是否已配置」，不回传原文。
+- 桌面版「设置」页只显示「是否已配置」，不回传原文。
+- 机器人 webhook 写在 `informer.json` 里，不进入这个文件；若旧版本曾把 webhook 写在这里，运行时仍会读取，并在下次保存地址时迁出。
 
 ## 五、订阅管理命令
 
@@ -282,7 +286,7 @@ API Key 不写进 `informer.json`，而是放在同目录的 `informer.secret.js
 | **订阅** | 左侧分类树：新增 / 编辑 / 删除分类，用整数「排序值」决定顺序（越小越靠前，相同排序值按分类 ID 排）。右侧按分类筛选的订阅卡片：展示解析类型、抓取状态、所属分类、错误信息，卡片右上角的开关直接启停订阅，底部可「测试抓取」（真实抓取，但不写库、不改订阅状态）、编辑、删除。 |
 | **日报** | 左侧按「年 → 月 → 日」折叠的日期列表，点击某天在右侧全宽渲染当天的 Markdown。单日内容一次性加载，不分页。 |
 | **文章库** | 已入库文章的游标翻页列表，可按分类、订阅、关键字筛选，显示通知时间；标题点击后在系统浏览器中打开。 |
-| **设置** | 读写 `informer.json` 的抓取与推荐参数、配置定时推送（仅桌面端，应用打开时生效）、手动触发一次推送、配置机器人地址（写入独立的敏感文件）、执行「重建历史索引」。 |
+| **设置** | 读写 `informer.json` 的抓取与推荐参数、配置定时推送（仅桌面端，应用打开时生效）、手动触发一次推送、配置机器人地址（写入 `informer.json`）、执行「重建历史索引」。 |
 
 正式发布构建会在启动时及之后每 24 小时检查一次 GitHub Releases；若有新版本则后台下载并校验，右上角出现「重启生效新版本」，点击后替换二进制并重启。开发版（`version=dev`）不会发起检查。
 

--- a/cmd/informer-ui/binding_manage_test.go
+++ b/cmd/informer-ui/binding_manage_test.go
@@ -20,7 +20,6 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -528,30 +527,28 @@ func TestWebhookBindingReturnsTheStoredAddress(t *testing.T) {
 
 	app := newTestApp(t)
 
-	view, err := app.ReadSecrets()
+	view, err := app.ReadConfig()
 	require.NoError(t, err)
-	assert.False(t, view.WebhookConfigured)
+	assert.Empty(t, view.Webhook)
 
-	const webhook = "https://open.feishu.cn/open-apis/bot/v2/hook/0000-secret-token"
+	const webhook = "https://open.feishu.cn/open-apis/bot/v2/hook/0000-plain-token"
 
 	require.NoError(t, app.SaveWebhook(webhook))
 
-	view, err = app.ReadSecrets()
+	view, err = app.ReadConfig()
 	require.NoError(t, err)
-	assert.True(t, view.WebhookConfigured)
 	assert.Equal(t, webhook, view.Webhook)
 
-	if runtime.GOOS != "windows" {
-		info, statErr := os.Stat(view.Path)
-		require.NoError(t, statErr)
-		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
-	}
+	secrets, err := app.ReadSecrets()
+	require.NoError(t, err)
+	_, err = os.Stat(secrets.Path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 
 	require.NoError(t, app.SaveWebhook(""))
 
-	view, err = app.ReadSecrets()
+	view, err = app.ReadConfig()
 	require.NoError(t, err)
-	assert.False(t, view.WebhookConfigured)
+	assert.Empty(t, view.Webhook)
 }
 
 func TestNewBindingsReportAStartupFailure(t *testing.T) {

--- a/cmd/informer-ui/binding_manage_test.go
+++ b/cmd/informer-ui/binding_manage_test.go
@@ -542,7 +542,7 @@ func TestWebhookBindingReturnsTheStoredAddress(t *testing.T) {
 	secrets, err := app.ReadSecrets()
 	require.NoError(t, err)
 	_, err = os.Stat(secrets.Path)
-	assert.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	require.NoError(t, app.SaveWebhook(""))
 

--- a/cmd/informer-ui/binding_settings.go
+++ b/cmd/informer-ui/binding_settings.go
@@ -81,22 +81,23 @@ type ConfigViewDTO struct {
 	// AgentProviders are the providers the agent section accepts, in order.
 	AgentProviders []string `json:"agentProviders"`
 
+	// Webhook is the bot delivery address stored in informer.json. It is a plain
+	// endpoint rather than a secret, so the settings page shows it in full.
+	Webhook string `json:"webhook"`
+
 	// PreservedKeys are the top level fields this build does not edit and keeps
 	// on every save, listed so the page can state that nothing is dropped.
 	PreservedKeys []string `json:"preservedKeys"`
 }
 
-// SecretsViewDTO is the credential state of the settings page. The webhook is a
-// plain bot address rather than a secret, so the page shows it in full.
+// SecretsViewDTO is the credential state of the settings page.
 type SecretsViewDTO struct {
-	Path              string `json:"path"`
-	Exists            bool   `json:"exists"`
-	WebhookConfigured bool   `json:"webhookConfigured"`
-	Webhook           string `json:"webhook"`
+	Path   string `json:"path"`
+	Exists bool   `json:"exists"`
 
 	// AgentAPIKeyConfigured reports whether an agent api key is stored. The key
-	// itself is never sent to the page: unlike the webhook it is a real
-	// credential, and the page only needs to know that one exists.
+	// itself is never sent to the page: it is a real credential, and the page
+	// only needs to know that one exists.
 	AgentAPIKeyConfigured bool `json:"agentApiKeyConfigured"`
 }
 
@@ -145,6 +146,7 @@ func (a *App) ReadConfig() (*ConfigViewDTO, error) {
 		Agent:            agentDefaults,
 		AgentDefaults:    agentDefaults,
 		AgentProviders:   agent.LegalProviders(),
+		Webhook:          view.Webhook,
 		PreservedKeys:    view.PreservedKeys,
 	}
 
@@ -189,7 +191,7 @@ func (a *App) SaveConfig(req *FeedConfigDTO) error {
 	})
 }
 
-// ReadSecrets reports whether a bot webhook is configured, and where it is stored.
+// ReadSecrets reports whether an agent api key is configured, and where it is stored.
 func (a *App) ReadSecrets() (*SecretsViewDTO, error) {
 	err := a.ready()
 	if err != nil {
@@ -204,15 +206,13 @@ func (a *App) ReadSecrets() (*SecretsViewDTO, error) {
 	return &SecretsViewDTO{
 		Path:                  view.Path,
 		Exists:                view.Exists,
-		WebhookConfigured:     view.WebhookConfigured,
-		Webhook:               view.Webhook,
 		AgentAPIKeyConfigured: view.AgentAPIKeyConfigured,
 	}, nil
 }
 
-// SaveWebhook stores the bot webhook in the separate 0600 credential file.
-// An empty value clears it. The save fails rather than leaving the file readable by
-// other users when the permission cannot be enforced.
+// SaveWebhook stores the bot webhook in informer.json.
+// An empty value clears it. A webhook left in the legacy credential file is removed
+// on save so the address is not kept in two places.
 func (a *App) SaveWebhook(webhook string) error {
 	err := a.ready()
 	if err != nil {

--- a/cmd/informer-ui/frontend/src/SettingsPanel.vue
+++ b/cmd/informer-ui/frontend/src/SettingsPanel.vue
@@ -110,10 +110,10 @@ async function load() {
     Object.assign(schedule, config.schedule)
     Object.assign(agent, config.agent)
     agentProviderOptions.value = (config.agentProviders ?? []).map(value => ({label: value, value}))
+    webhook.value = config.webhook ?? ''
+    webhookConfigured.value = webhook.value.trim() !== ''
 
     secretsPath.value = secrets.path
-    webhookConfigured.value = secrets.webhookConfigured
-    webhook.value = secrets.webhook
     agentAPIKeyConfigured.value = secrets.agentApiKeyConfigured
   } catch (e) {
     loadError.value = errorText(e)
@@ -353,7 +353,7 @@ async function rebuild() {
           <n-button :loading="agentAPIKeySaving" @click="saveAgentAPIKey">保存 Key</n-button>
         </n-space>
         <n-text depth="3" style="display: block; margin-top: 8px; font-size: 12px">
-          API Key 与机器人地址存放在同一个 0600 文件中，不会写入 informer.json。
+          API Key 存放在独立的 0600 文件 <n-code :code="secretsPath" inline /> 中，不会写入 informer.json。
         </n-text>
 
         <template #footer>
@@ -365,7 +365,7 @@ async function rebuild() {
 
       <n-card size="small" title="机器人地址" style="margin-bottom: 16px">
         <n-text depth="3" style="font-size: 12px">
-          存放于独立文件 <n-code :code="secretsPath" inline />，权限固定为 0600，不写入 informer.json，也不入库。
+          写入 <n-code :code="configPath" inline /> 的顶层 <n-code code="webhook" inline /> 字段，不是敏感凭证，也不入库。
         </n-text>
 
         <n-descriptions :column="1" size="small" style="margin: 12px 0">

--- a/examples/informer.json
+++ b/examples/informer.json
@@ -16,5 +16,6 @@
   "schedule": {
     "enabled": false,
     "time": "10:00"
-  }
+  },
+  "webhook": "https://oapi.dingtalk.com/robot/send?access_token=xxxxx"
 }

--- a/internal/configstore/configstore_test.go
+++ b/internal/configstore/configstore_test.go
@@ -92,6 +92,32 @@ func TestDocKeepsUnknownFieldsAndOrder(t *testing.T) {
 	assert.Equal(t, []int{1, 2}, future.Nested)
 }
 
+func TestDocDeleteRemovesAKey(t *testing.T) {
+	t.Parallel()
+
+	path := writeFile(t, `{
+  "note": "kept",
+  "webhook": "https://example.com/hook",
+  "feed": {"max_fetch_num": 1}
+}`)
+
+	doc, err := configstore.Load(path)
+	require.NoError(t, err)
+
+	doc.Delete("webhook")
+	doc.Delete("missing")
+
+	assert.Equal(t, []string{noteKey, feedKey}, doc.Keys())
+
+	data, err := doc.Bytes()
+	require.NoError(t, err)
+	require.NoError(t, configstore.WriteAtomic(path, data, configstore.PermConfig))
+
+	reloaded, err := configstore.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteKey, feedKey}, reloaded.Keys())
+}
+
 func TestDocUnmarshalReportsMissingAndBrokenFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/configstore/doc.go
+++ b/internal/configstore/doc.go
@@ -101,6 +101,24 @@ func (d *Doc) Set(key string, value any) error {
 	return nil
 }
 
+// Delete removes one top level key. A missing key is a no-op so a save that
+// clears a field never has to ask whether the file still carried it.
+func (d *Doc) Delete(key string) {
+	if _, ok := d.fields[key]; !ok {
+		return
+	}
+
+	delete(d.fields, key)
+
+	for i, existing := range d.order {
+		if existing == key {
+			d.order = append(d.order[:i], d.order[i+1:]...)
+
+			return
+		}
+	}
+}
+
 // Bytes renders the document as indented json, in the original field order and with
 // a trailing newline, so the result stays a file a human can read and diff.
 func (d *Doc) Bytes() ([]byte, error) {

--- a/internal/inform/informer.go
+++ b/internal/inform/informer.go
@@ -71,6 +71,10 @@ type Config struct {
 	// Agent is the shared configuration of every agent source. A nil value runs
 	// the agent with its defaults and the machine's own credentials.
 	Agent *agent.Config `json:"agent"`
+
+	// Webhook is the bot delivery address. It is a plain endpoint rather than a
+	// credential, so it lives in the shareable configuration file.
+	Webhook string `json:"webhook,omitempty"`
 }
 
 // Options describes one inform run. The feed database is expected to be

--- a/internal/service/agentconfig.go
+++ b/internal/service/agentconfig.go
@@ -40,8 +40,8 @@ func DefaultAgentConfig() *agent.Config {
 }
 
 // agentSection is the agent part of informer.json exactly as the file spells it.
-// The api key is deliberately absent: it lives in the 0600 credential file next to
-// the bot webhook, so informer.json stays a document that can be shared and diffed.
+// The api key is deliberately absent: it lives in the 0600 credential file, so
+// informer.json stays a document that can be shared and diffed.
 type agentSection struct {
 	Provider       string `json:"provider"`
 	BaseURL        string `json:"base_url"`

--- a/internal/service/agentconfig_test.go
+++ b/internal/service/agentconfig_test.go
@@ -131,7 +131,7 @@ func TestAgentAPIKeyIsStoredInTheCredentialFile(t *testing.T) {
 	assert.False(t, view.AgentAPIKeyConfigured)
 }
 
-func TestAgentAPIKeyAndWebhookShareTheFileWithoutOverwriting(t *testing.T) {
+func TestAgentAPIKeySurvivesWebhookSaves(t *testing.T) {
 	svc := newService(t)
 
 	require.NoError(t, svc.SaveWebhook("https://open.feishu.cn/hook/x"))
@@ -139,15 +139,21 @@ func TestAgentAPIKeyAndWebhookShareTheFileWithoutOverwriting(t *testing.T) {
 
 	view, err := svc.ReadSecretsView()
 	require.NoError(t, err)
-	assert.Equal(t, "https://open.feishu.cn/hook/x", view.Webhook)
 	assert.True(t, view.AgentAPIKeyConfigured)
+
+	configView, err := svc.ReadFileConfigView()
+	require.NoError(t, err)
+	assert.Equal(t, "https://open.feishu.cn/hook/x", configView.Webhook)
 
 	require.NoError(t, svc.SaveWebhook(""))
 
 	view, err = svc.ReadSecretsView()
 	require.NoError(t, err)
-	assert.False(t, view.WebhookConfigured)
-	assert.True(t, view.AgentAPIKeyConfigured, "clearing one credential leaves the other in place")
+	assert.True(t, view.AgentAPIKeyConfigured, "clearing the webhook leaves the api key in place")
+
+	configView, err = svc.ReadFileConfigView()
+	require.NoError(t, err)
+	assert.Empty(t, configView.Webhook)
 }
 
 func TestEffectiveAgentConfigCombinesFileSectionKeyAndHomeDir(t *testing.T) {

--- a/internal/service/fileconfig.go
+++ b/internal/service/fileconfig.go
@@ -71,6 +71,10 @@ type FileConfigView struct {
 	// Agent is the editable agent section, nil when the file defines none.
 	Agent *agent.Config `json:"agent"`
 
+	// Webhook is the bot delivery address stored in informer.json. It is a plain
+	// endpoint rather than a secret, so the settings page shows it in full.
+	Webhook string `json:"webhook"`
+
 	// PreservedKeys lists the top level keys this build does not edit but keeps on
 	// save, so the page can state plainly that nothing else is dropped.
 	PreservedKeys []string `json:"preserved_keys"`
@@ -131,8 +135,13 @@ func (s *Service) ReadFileConfigView() (*FileConfigView, error) {
 		return nil, err
 	}
 
+	view.Webhook, err = s.readWebhook()
+	if err != nil {
+		return nil, err
+	}
+
 	for _, key := range doc.Keys() {
-		if key != feedSectionKey && key != scheduleSectionKey && key != agentSectionKey {
+		if key != feedSectionKey && key != scheduleSectionKey && key != agentSectionKey && key != webhookKey {
 			view.PreservedKeys = append(view.PreservedKeys, key)
 		}
 	}

--- a/internal/service/helper_test.go
+++ b/internal/service/helper_test.go
@@ -31,6 +31,9 @@ import (
 	"github.com/vogo/informer/internal/service"
 )
 
+// windowsGOOS is the platform that does not model unix permission bits.
+const windowsGOOS = "windows"
+
 // atomFeed is a minimal but valid atom document served by the test feed endpoint.
 const atomFeed = `<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/internal/service/inform.go
+++ b/internal/service/inform.go
@@ -30,7 +30,7 @@ import (
 // same site limit, build the message, store the daily file and deliver it to the bot
 // at urlAddr. It is the single entry point of the scheduled CLI notification.
 //
-// An empty urlAddr falls back to the webhook stored in the credential file, so a run
+// An empty urlAddr falls back to the webhook stored in informer.json, so a run
 // started without an argument still delivers what the desktop app configured.
 //
 // The inform timestamp of the selected articles is written only after the

--- a/internal/service/secrets.go
+++ b/internal/service/secrets.go
@@ -27,15 +27,10 @@ import (
 const (
 	// SecretsFileName is the credential file of one data directory. It is kept out of
 	// informer.json on purpose: informer.json is meant to be readable, diffable and
-	// shareable, while the bot webhook stays in its own locked-down file.
+	// shareable, while the agent api key stays in its own locked-down file.
 	SecretsFileName = "informer.secret.json"
 
-	// webhookKey is the top level key holding the bot webhook.
-	webhookKey = "webhook"
-
-	// agentAPIKeyKey is the top level key holding the agent api key. It shares
-	// the credential file with the webhook because both are things a data
-	// directory must not hand out when informer.json is shared.
+	// agentAPIKeyKey is the top level key holding the agent api key.
 	agentAPIKeyKey = "agent_api_key" //nolint:gosec //document key name, not a credential.
 )
 
@@ -47,16 +42,9 @@ type SecretsView struct {
 	// Exists reports whether the file is already on disk.
 	Exists bool `json:"exists"`
 
-	// WebhookConfigured reports whether a non empty webhook is stored.
-	WebhookConfigured bool `json:"webhook_configured"`
-
-	// Webhook is the stored bot address. It is a plain endpoint rather than a
-	// secret, so the settings page shows it in full.
-	Webhook string `json:"webhook"`
-
 	// AgentAPIKeyConfigured reports whether a non empty agent api key is stored.
-	// The key itself is never returned: unlike the webhook it is a real
-	// credential, and the page only needs to know that one is set.
+	// The key itself is never returned: it is a real credential, and the page only
+	// needs to know that one is set.
 	AgentAPIKeyConfigured bool `json:"agent_api_key_configured"`
 }
 
@@ -77,16 +65,8 @@ func (s *Service) ReadSecretsView() (*SecretsView, error) {
 	return &SecretsView{
 		Path:                  path,
 		Exists:                stored.exists,
-		WebhookConfigured:     stored.webhook != "",
-		Webhook:               stored.webhook,
 		AgentAPIKeyConfigured: stored.agentAPIKey != "",
 	}, nil
-}
-
-// SaveWebhook stores the bot webhook in the credential file.
-// An empty value clears the stored webhook rather than writing a blank one.
-func (s *Service) SaveWebhook(webhook string) error {
-	return s.saveSecret(webhookKey, webhook)
 }
 
 // SaveAgentAPIKey stores the agent api key in the credential file.
@@ -126,26 +106,6 @@ func (s *Service) saveSecret(key, value string) error {
 	})
 }
 
-// ResolveWebhook decides which bot webhook one inform run delivers to.
-//
-// An address passed on the command line always wins, so every existing crontab entry
-// keeps working exactly as before; the credential file is the fallback used by a run
-// started without an argument, which is how the desktop app configures delivery.
-func (s *Service) ResolveWebhook(argAddr string) string {
-	if trimmed := strings.TrimSpace(argAddr); trimmed != "" {
-		return trimmed
-	}
-
-	stored, err := s.readSecrets()
-	if err != nil {
-		// a broken credential file must not abort the daily run: the report is still
-		// generated and stored, it is only not delivered.
-		return ""
-	}
-
-	return stored.webhook
-}
-
 // readAgentAPIKey returns the stored agent api key, empty when none is configured.
 func (s *Service) readAgentAPIKey() (string, error) {
 	stored, err := s.readSecrets()
@@ -158,7 +118,6 @@ func (s *Service) readAgentAPIKey() (string, error) {
 
 // storedSecrets is the credential file state one read resolved.
 type storedSecrets struct {
-	webhook     string
 	agentAPIKey string
 	exists      bool
 }
@@ -172,13 +131,6 @@ func (s *Service) readSecrets() (storedSecrets, error) {
 
 	stored := storedSecrets{exists: doc.Exists()}
 
-	var webhook string
-
-	_, err = doc.Unmarshal(webhookKey, &webhook)
-	if err != nil {
-		return stored, err
-	}
-
 	var apiKey string
 
 	_, err = doc.Unmarshal(agentAPIKeyKey, &apiKey)
@@ -186,7 +138,6 @@ func (s *Service) readSecrets() (storedSecrets, error) {
 		return stored, err
 	}
 
-	stored.webhook = strings.TrimSpace(webhook)
 	stored.agentAPIKey = strings.TrimSpace(apiKey)
 
 	return stored, nil

--- a/internal/service/settings_test.go
+++ b/internal/service/settings_test.go
@@ -182,7 +182,7 @@ func TestSaveWebhookWritesToInformerJSON(t *testing.T) {
 
 	// the credential file is not created for a plain bot address.
 	_, err = os.Stat(svc.SecretsFilePath())
-	assert.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestSaveWebhookMigratesALegacySecretEntry(t *testing.T) {

--- a/internal/service/settings_test.go
+++ b/internal/service/settings_test.go
@@ -222,7 +222,7 @@ func TestSaveWebhookClearsTheStoredValue(t *testing.T) {
 func TestResolveWebhookIgnoresABrokenConfigFile(t *testing.T) {
 	svc := newService(t)
 
-	require.NoError(t, os.WriteFile(svc.ConfigFilePath(), []byte("not json"), 0o644))
+	require.NoError(t, os.WriteFile(svc.ConfigFilePath(), []byte("not json"), 0o644)) //nolint:gosec //broken fixture on purpose.
 
 	// the daily report must still be generated; only the delivery is skipped.
 	assert.Empty(t, svc.ResolveWebhook(""))

--- a/internal/service/settings_test.go
+++ b/internal/service/settings_test.go
@@ -20,7 +20,6 @@ package service_test
 import (
 	"encoding/json"
 	"os"
-	"runtime"
 	"sync"
 	"testing"
 
@@ -30,9 +29,6 @@ import (
 	"github.com/vogo/informer/internal/feed"
 	"github.com/vogo/informer/internal/service"
 )
-
-// windowsGOOS is the platform that does not model unix permission bits.
-const windowsGOOS = "windows"
 
 // validFeedConfig is a feed section every validation rule accepts.
 func validFeedConfig() *feed.Config {
@@ -157,28 +153,25 @@ func TestSaveFeedConfigSurvivesConcurrentWriters(t *testing.T) {
 	assert.Equal(t, 150, view.Feed.FeedExpireDays)
 }
 
-func TestSaveWebhookWritesASensitiveFile(t *testing.T) {
+func TestSaveWebhookWritesToInformerJSON(t *testing.T) {
 	svc := newService(t)
 
-	view, err := svc.ReadSecretsView()
+	view, err := svc.ReadFileConfigView()
 	require.NoError(t, err)
-	assert.False(t, view.Exists)
-	assert.False(t, view.WebhookConfigured)
 	assert.Empty(t, view.Webhook)
 
-	const webhook = "https://oapi.dingtalk.com/robot/send?access_token=super-secret-token"
+	const webhook = "https://oapi.dingtalk.com/robot/send?access_token=plain-bot-token"
 
 	require.NoError(t, svc.SaveWebhook(webhook))
 
-	view, err = svc.ReadSecretsView()
+	view, err = svc.ReadFileConfigView()
 	require.NoError(t, err)
 	assert.True(t, view.Exists)
-	assert.True(t, view.WebhookConfigured)
-
-	// the bot address is a plain endpoint, so the settings page sees it in full.
 	assert.Equal(t, webhook, view.Webhook)
 
-	assertSecretPermission(t, svc.SecretsFilePath())
+	raw := readConfigFile(t, svc)
+	assert.Equal(t, webhook, raw["webhook"])
+	assert.NotContains(t, raw, "id")
 
 	// the stored webhook is what an argument free inform run delivers to.
 	assert.Equal(t, webhook, svc.ResolveWebhook(""))
@@ -186,21 +179,31 @@ func TestSaveWebhookWritesASensitiveFile(t *testing.T) {
 
 	// an explicit command line address still wins, so crontab keeps its behavior.
 	assert.Equal(t, "https://example.com/hook", svc.ResolveWebhook("https://example.com/hook"))
+
+	// the credential file is not created for a plain bot address.
+	_, err = os.Stat(svc.SecretsFilePath())
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
-func TestSaveWebhookRewritesAnInsecureFileSecurely(t *testing.T) {
-	if runtime.GOOS == windowsGOOS {
-		t.Skip("windows does not model unix permission bits")
-	}
-
+func TestSaveWebhookMigratesALegacySecretEntry(t *testing.T) {
 	svc := newService(t)
 
-	// deliberately world readable, to prove the save locks the file down again.
-	require.NoError(t, os.WriteFile(svc.SecretsFilePath(), []byte(`{"webhook":"old"}`), 0o644)) //nolint:gosec //see above.
+	require.NoError(t, os.WriteFile(svc.SecretsFilePath(), []byte(`{"webhook":"https://legacy.example/hook","agent_api_key":"sk-keep"}`), 0o600))
+
+	assert.Equal(t, "https://legacy.example/hook", svc.ResolveWebhook(""))
+
 	require.NoError(t, svc.SaveWebhook("https://example.com/new"))
 
-	assertSecretPermission(t, svc.SecretsFilePath())
 	assert.Equal(t, "https://example.com/new", svc.ResolveWebhook(""))
+	assert.Equal(t, "https://example.com/new", readConfigFile(t, svc)["webhook"])
+
+	raw, err := os.ReadFile(svc.SecretsFilePath())
+	require.NoError(t, err)
+
+	var secrets map[string]any
+	require.NoError(t, json.Unmarshal(raw, &secrets))
+	assert.NotContains(t, secrets, "webhook")
+	assert.Equal(t, "sk-keep", secrets["agent_api_key"])
 }
 
 func TestSaveWebhookClearsTheStoredValue(t *testing.T) {
@@ -209,37 +212,23 @@ func TestSaveWebhookClearsTheStoredValue(t *testing.T) {
 	require.NoError(t, svc.SaveWebhook("https://example.com/hook"))
 	require.NoError(t, svc.SaveWebhook(""))
 
-	view, err := svc.ReadSecretsView()
+	view, err := svc.ReadFileConfigView()
 	require.NoError(t, err)
-	assert.True(t, view.Exists)
-	assert.False(t, view.WebhookConfigured)
+	assert.Empty(t, view.Webhook)
 	assert.Empty(t, svc.ResolveWebhook(""))
-
-	assertSecretPermission(t, svc.SecretsFilePath())
+	assert.NotContains(t, readConfigFile(t, svc), "webhook")
 }
 
-func TestResolveWebhookIgnoresABrokenSecretFile(t *testing.T) {
+func TestResolveWebhookIgnoresABrokenConfigFile(t *testing.T) {
 	svc := newService(t)
 
-	require.NoError(t, os.WriteFile(svc.SecretsFilePath(), []byte("not json"), 0o600))
+	require.NoError(t, os.WriteFile(svc.ConfigFilePath(), []byte("not json"), 0o644))
 
 	// the daily report must still be generated; only the delivery is skipped.
 	assert.Empty(t, svc.ResolveWebhook(""))
 
-	_, err := svc.ReadSecretsView()
+	_, err := svc.ReadFileConfigView()
 	require.Error(t, err)
-}
-
-func assertSecretPermission(t *testing.T, path string) {
-	t.Helper()
-
-	if runtime.GOOS == windowsGOOS {
-		return
-	}
-
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
 func readConfigFile(t *testing.T, svc *service.Service) map[string]any {

--- a/internal/service/webhook.go
+++ b/internal/service/webhook.go
@@ -19,6 +19,7 @@ package service
 
 import (
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/vogo/informer/internal/configstore"
@@ -70,7 +71,7 @@ func (s *Service) SaveWebhook(webhook string) error {
 // An address passed on the command line always wins, so every existing crontab entry
 // keeps working exactly as before; informer.json is the fallback used by a run
 // started without an argument. A webhook still sitting in the legacy credential
-// file is honoured until the next save migrates it out.
+// file is honored until the next save migrates it out.
 func (s *Service) ResolveWebhook(argAddr string) string {
 	if trimmed := strings.TrimSpace(argAddr); trimmed != "" {
 		return trimmed
@@ -106,26 +107,26 @@ func (s *Service) readWebhook() (string, error) {
 		return webhook, nil
 	}
 
-	return s.readLegacyWebhook()
+	return s.readLegacyWebhook(), nil
 }
 
 // readLegacyWebhook returns a webhook still stored in informer.secret.json.
-// Failures are treated as "no legacy address": a broken credential file must not
+// A missing or broken credential file means "no legacy address": it must not
 // block reading the shareable configuration.
-func (s *Service) readLegacyWebhook() (string, error) {
+func (s *Service) readLegacyWebhook() string {
 	doc, err := configstore.Load(s.SecretsFilePath())
 	if err != nil {
-		return "", nil
+		return ""
 	}
 
 	var webhook string
 
 	_, err = doc.Unmarshal(webhookKey, &webhook)
 	if err != nil {
-		return "", nil
+		return ""
 	}
 
-	return strings.TrimSpace(webhook), nil
+	return strings.TrimSpace(webhook)
 }
 
 // clearLegacyWebhook drops the webhook key from the credential file when one is
@@ -134,51 +135,44 @@ func (s *Service) readLegacyWebhook() (string, error) {
 func (s *Service) clearLegacyWebhook() error {
 	path := s.SecretsFilePath()
 
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			return nil
+	_, err := os.Stat(path)
+	if err != nil {
+		return nil //nolint:nilerr //missing or unreadable secret file means nothing to migrate.
+	}
+
+	return configstore.WithLock(path, configstore.DefaultLockTimeout, func() error {
+		return removeLegacyWebhookKey(path)
+	})
+}
+
+// removeLegacyWebhookKey deletes the webhook key from path when present.
+func removeLegacyWebhookKey(path string) error {
+	doc, err := configstore.Load(path)
+	if err != nil {
+		return nil //nolint:nilerr //legacy cleanup is best effort after the config write.
+	}
+
+	if !slices.Contains(doc.Keys(), webhookKey) {
+		return nil
+	}
+
+	doc.Delete(webhookKey)
+
+	// an empty credential file is removed rather than rewritten as {}, so an
+	// installation that only ever stored a webhook does not keep a useless file.
+	if len(doc.Keys()) == 0 {
+		removeErr := os.Remove(path)
+		if removeErr != nil && !os.IsNotExist(removeErr) {
+			return removeErr
 		}
 
 		return nil
 	}
 
-	return configstore.WithLock(path, configstore.DefaultLockTimeout, func() error {
-		doc, err := configstore.Load(path)
-		if err != nil {
-			return nil
-		}
+	data, err := doc.Bytes()
+	if err != nil {
+		return err
+	}
 
-		had := false
-		for _, key := range doc.Keys() {
-			if key == webhookKey {
-				had = true
-
-				break
-			}
-		}
-
-		if !had {
-			return nil
-		}
-
-		doc.Delete(webhookKey)
-
-		// an empty credential file is removed rather than rewritten as {}, so an
-		// installation that only ever stored a webhook does not keep a useless file.
-		if len(doc.Keys()) == 0 {
-			removeErr := os.Remove(path)
-			if removeErr != nil && !os.IsNotExist(removeErr) {
-				return removeErr
-			}
-
-			return nil
-		}
-
-		data, err := doc.Bytes()
-		if err != nil {
-			return err
-		}
-
-		return configstore.WriteAtomic(path, data, configstore.PermSecret)
-	})
+	return configstore.WriteAtomic(path, data, configstore.PermSecret)
 }

--- a/internal/service/webhook.go
+++ b/internal/service/webhook.go
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"os"
+	"strings"
+
+	"github.com/vogo/informer/internal/configstore"
+)
+
+// webhookKey is the top level key holding the bot webhook inside informer.json.
+// It is a plain delivery address rather than a credential, so it lives next to
+// the other shareable settings and never enters informer.secret.json.
+const webhookKey = "webhook"
+
+// SaveWebhook stores the bot webhook in informer.json.
+// An empty value clears it. A webhook left behind in the legacy credential file
+// is removed on every save so an installation that upgrades does not keep two
+// copies of the same address.
+func (s *Service) SaveWebhook(webhook string) error {
+	trimmed := strings.TrimSpace(webhook)
+
+	err := configstore.WithLock(s.ConfigFilePath(), configstore.DefaultLockTimeout, func() error {
+		doc, loadErr := configstore.Load(s.ConfigFilePath())
+		if loadErr != nil {
+			return loadErr
+		}
+
+		if trimmed == "" {
+			doc.Delete(webhookKey)
+		} else {
+			setErr := doc.Set(webhookKey, trimmed)
+			if setErr != nil {
+				return setErr
+			}
+		}
+
+		data, bytesErr := doc.Bytes()
+		if bytesErr != nil {
+			return bytesErr
+		}
+
+		return configstore.WriteAtomic(s.ConfigFilePath(), data, configstore.PermConfig)
+	})
+	if err != nil {
+		return err
+	}
+
+	return s.clearLegacyWebhook()
+}
+
+// ResolveWebhook decides which bot webhook one inform run delivers to.
+//
+// An address passed on the command line always wins, so every existing crontab entry
+// keeps working exactly as before; informer.json is the fallback used by a run
+// started without an argument. A webhook still sitting in the legacy credential
+// file is honoured until the next save migrates it out.
+func (s *Service) ResolveWebhook(argAddr string) string {
+	if trimmed := strings.TrimSpace(argAddr); trimmed != "" {
+		return trimmed
+	}
+
+	webhook, err := s.readWebhook()
+	if err != nil {
+		// a broken configuration must not abort the daily run: the report is still
+		// generated and stored, it is only not delivered.
+		return ""
+	}
+
+	return webhook
+}
+
+// readWebhook returns the stored bot address from informer.json, falling back to
+// the legacy credential file for installations that have not saved since the move.
+func (s *Service) readWebhook() (string, error) {
+	doc, err := configstore.Load(s.ConfigFilePath())
+	if err != nil {
+		return "", err
+	}
+
+	var webhook string
+
+	_, err = doc.Unmarshal(webhookKey, &webhook)
+	if err != nil {
+		return "", err
+	}
+
+	webhook = strings.TrimSpace(webhook)
+	if webhook != "" {
+		return webhook, nil
+	}
+
+	return s.readLegacyWebhook()
+}
+
+// readLegacyWebhook returns a webhook still stored in informer.secret.json.
+// Failures are treated as "no legacy address": a broken credential file must not
+// block reading the shareable configuration.
+func (s *Service) readLegacyWebhook() (string, error) {
+	doc, err := configstore.Load(s.SecretsFilePath())
+	if err != nil {
+		return "", nil
+	}
+
+	var webhook string
+
+	_, err = doc.Unmarshal(webhookKey, &webhook)
+	if err != nil {
+		return "", nil
+	}
+
+	return strings.TrimSpace(webhook), nil
+}
+
+// clearLegacyWebhook drops the webhook key from the credential file when one is
+// still present. Failures are ignored: the address already lives in informer.json,
+// and a later save can try again.
+func (s *Service) clearLegacyWebhook() error {
+	path := s.SecretsFilePath()
+
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return nil
+	}
+
+	return configstore.WithLock(path, configstore.DefaultLockTimeout, func() error {
+		doc, err := configstore.Load(path)
+		if err != nil {
+			return nil
+		}
+
+		had := false
+		for _, key := range doc.Keys() {
+			if key == webhookKey {
+				had = true
+
+				break
+			}
+		}
+
+		if !had {
+			return nil
+		}
+
+		doc.Delete(webhookKey)
+
+		// an empty credential file is removed rather than rewritten as {}, so an
+		// installation that only ever stored a webhook does not keep a useless file.
+		if len(doc.Keys()) == 0 {
+			removeErr := os.Remove(path)
+			if removeErr != nil && !os.IsNotExist(removeErr) {
+				return removeErr
+			}
+
+			return nil
+		}
+
+		data, err := doc.Bytes()
+		if err != nil {
+			return err
+		}
+
+		return configstore.WriteAtomic(path, data, configstore.PermSecret)
+	})
+}


### PR DESCRIPTION
## Summary
- Move the robot webhook from `informer.secret.json` into top-level `webhook` in `informer.json` (it is not a secret).
- Keep only `agent_api_key` in the 0600 credential file; settings UI and README updated accordingly.
- Legacy secret-file webhooks still work until the next save, which migrates them out.

## Test plan
- [x] `go test ./internal/service/ ./internal/configstore/`
- [x] `go test .` in `cmd/informer-ui`
- [ ] Save a webhook in settings and confirm it appears in `informer.json`, not `informer.secret.json`
- [ ] Confirm an old `informer.secret.json` webhook still delivers until re-saved

Made with [Cursor](https://cursor.com)