### PR TITLE
feat: route in-app updater through http_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ informer 不会自动同步多个数据主目录，也不支持同时使用多�
 | --- | --- | --- |
 | `webhook` | 推送用的机器人 webhook | URL 字符串；留空或不写表示不推送 |
 
-还有一个顶层字段 `http_proxy`，供 URL 抓取与 Agent 子进程共用：
+还有一个顶层字段 `http_proxy`，供 URL 抓取、桌面版应用内更新与 Agent 子进程共用：
 
 | 配置项 | 含义 | 取值 |
 | --- | --- | --- |
 | `http_proxy` | HTTP(S) 代理地址 | 如 `http://127.0.0.1:7890`；留空或不写表示不使用代理 |
 
-有配置时，订阅抓取、每日鸡汤、机器人推送会经共享 HTTP 客户端走代理；Agent（如 `claude`）子进程会注入 `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY`。这与 `agent.base_url`（API 网关地址）无关。
+有配置时，订阅抓取、每日鸡汤、机器人推送与桌面版检查/下载新版本会经共享 HTTP 客户端走代理；Agent（如 `claude`）子进程会注入 `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY`。这与 `agent.base_url`（API 网关地址）无关。
 
 还有一个顶层节 `schedule`，只被桌面版「定时任务」读取，命令行与系统 crontab 会忽略它（命令行的定时推送仍由 crontab 负责）：
 

--- a/cmd/informer-ui/main.go
+++ b/cmd/informer-ui/main.go
@@ -32,6 +32,8 @@ import (
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/updater"
 	"github.com/wailsapp/wails/v3/pkg/updater/providers/github"
+
+	"github.com/vogo/informer/internal/httpx"
 )
 
 // appTitle is the product name shown in the window chrome, kept in one place
@@ -43,6 +45,9 @@ const githubRepo = "vogo/informer"
 
 // checksumAsset is the fixed checksums filename published with each release.
 const checksumAsset = "SHA256SUMS"
+
+// updaterHTTPTimeout covers GitHub API checks and full release archive downloads.
+const updaterHTTPTimeout = 10 * time.Minute
 
 const (
 	platformDarwin  = "darwin"
@@ -120,6 +125,7 @@ func initUpdater(app *application.App) error {
 		Repository:    githubRepo,
 		ChecksumAsset: checksumAsset,
 		AssetMatcher:  informerAssetMatcher,
+		HTTPClient:    httpx.NewClient(updaterHTTPTimeout),
 	})
 	if err != nil {
 		return err

--- a/internal/httpx/http.go
+++ b/internal/httpx/http.go
@@ -118,6 +118,16 @@ func CurrentProxy() string {
 	return proxy.String()
 }
 
+// NewClient returns an http.Client that shares HTTPClient's Transport and
+// therefore honors the same configured http_proxy. The caller supplies the
+// per-request timeout; no cookie jar is attached.
+func NewClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Transport: HTTPClient.Transport,
+		Timeout:   timeout,
+	}
+}
+
 //nolint:gochecknoglobals //ignore this.
 var defaultHTTPHeaders = map[string]string{
 	"accept":          "*/*",

--- a/internal/httpx/proxy_test.go
+++ b/internal/httpx/proxy_test.go
@@ -55,6 +55,20 @@ func TestSetProxyClearsWhenEmpty(t *testing.T) {
 	assert.Nil(t, proxy)
 }
 
+func TestNewClientHonorsConfiguredProxy(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, httpx.SetProxy(""))
+	})
+
+	require.NoError(t, httpx.SetProxy("http://127.0.0.1:7890"))
+
+	client := httpx.NewClient(0)
+	proxy, err := client.Transport.(*http.Transport).Proxy(nil)
+	require.NoError(t, err)
+	require.NotNil(t, proxy)
+	assert.Equal(t, "http://127.0.0.1:7890", proxy.String())
+}
+
 func TestSetProxyRejectsAnInvalidURL(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, httpx.SetProxy(""))


### PR DESCRIPTION
## Summary
- Inject a proxy-aware `httpx.NewClient` into the Wails GitHub updater so version checks and release downloads honor `informer.json` `http_proxy`
- Document the behavior and cover `NewClient` with a unit test

## Test plan
- [x] `go test ./internal/httpx/...`
- [x] `go test ./...` in `cmd/informer-ui`
- [ ] With `http_proxy` set, confirm updater check/download succeeds via proxy


Made with [Cursor](https://cursor.com)